### PR TITLE
feat: add desktop runtime shell and strict IPC contracts

### DIFF
--- a/desktop/ipc/contracts.ts
+++ b/desktop/ipc/contracts.ts
@@ -1,0 +1,60 @@
+export const ipcChannels = {
+  listDevices: 'runtime:list-devices',
+  connectDevice: 'runtime:connect-device',
+  disconnectDevice: 'runtime:disconnect-device',
+  sendFrame: 'runtime:send-frame',
+  runtimeStatus: 'runtime:status'
+} as const;
+
+export type IpcChannel = (typeof ipcChannels)[keyof typeof ipcChannels];
+
+export type DeviceProtocol = 'dmx' | 'artnet' | 'osc';
+
+export type HardwareDevice = {
+  id: string;
+  name: string;
+  protocol: DeviceProtocol;
+  online: boolean;
+};
+
+export type RuntimeStatus = {
+  ready: boolean;
+  connectedDeviceId: string | null;
+  protocol: DeviceProtocol | null;
+};
+
+export type ConnectDeviceRequest = {
+  deviceId: string;
+};
+
+export type SendFrameRequest = {
+  universe: number;
+  channelValues: number[];
+};
+
+export type NativeIpcApi = {
+  listDevices: () => Promise<HardwareDevice[]>;
+  connectDevice: (request: ConnectDeviceRequest) => Promise<RuntimeStatus>;
+  disconnectDevice: () => Promise<RuntimeStatus>;
+  sendFrame: (request: SendFrameRequest) => Promise<void>;
+  getRuntimeStatus: () => Promise<RuntimeStatus>;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+export function assertConnectDeviceRequest(value: unknown): asserts value is ConnectDeviceRequest {
+  if (!isRecord(value) || typeof value.deviceId !== 'string' || value.deviceId.length === 0) {
+    throw new Error('Invalid connect device payload.');
+  }
+}
+
+export function assertSendFrameRequest(value: unknown): asserts value is SendFrameRequest {
+  if (!isRecord(value) || typeof value.universe !== 'number' || !Number.isInteger(value.universe) || value.universe < 0) {
+    throw new Error('Invalid frame payload: universe must be a positive integer.');
+  }
+
+  if (!Array.isArray(value.channelValues) || value.channelValues.some((v) => !Number.isInteger(v) || v < 0 || v > 255)) {
+    throw new Error('Invalid frame payload: channelValues must be an array of DMX bytes (0-255).');
+  }
+}

--- a/desktop/ipc/handlers.ts
+++ b/desktop/ipc/handlers.ts
@@ -1,0 +1,25 @@
+import { ipcMain } from 'electron';
+import {
+  assertConnectDeviceRequest,
+  assertSendFrameRequest,
+  ipcChannels
+} from './contracts';
+import type { HardwareRuntime } from '../native/hardwareRuntime';
+
+export function registerIpcHandlers(runtime: HardwareRuntime): void {
+  ipcMain.handle(ipcChannels.listDevices, () => runtime.listDevices());
+
+  ipcMain.handle(ipcChannels.connectDevice, (_event, payload: unknown) => {
+    assertConnectDeviceRequest(payload);
+    return runtime.connectDevice(payload);
+  });
+
+  ipcMain.handle(ipcChannels.disconnectDevice, () => runtime.disconnectDevice());
+
+  ipcMain.handle(ipcChannels.sendFrame, (_event, payload: unknown) => {
+    assertSendFrameRequest(payload);
+    runtime.sendFrame(payload);
+  });
+
+  ipcMain.handle(ipcChannels.runtimeStatus, () => runtime.getStatus());
+}

--- a/desktop/main.ts
+++ b/desktop/main.ts
@@ -1,0 +1,37 @@
+import { app, BrowserWindow } from 'electron';
+import { registerIpcHandlers } from './ipc/handlers';
+import { HardwareRuntime } from './native/hardwareRuntime';
+
+const runtime = new HardwareRuntime();
+
+function createWindow(): void {
+  const mainWindow = new BrowserWindow({
+    width: 1440,
+    height: 900,
+    webPreferences: {
+      preload: new URL('./preload.ts', import.meta.url).pathname,
+      contextIsolation: true,
+      nodeIntegration: false
+    }
+  });
+
+  const rendererUrl = process.env.LIGHTAI_UI_URL ?? 'http://localhost:5173';
+  void mainWindow.loadURL(rendererUrl);
+}
+
+app.whenReady().then(() => {
+  registerIpcHandlers(runtime);
+  createWindow();
+
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) {
+      createWindow();
+    }
+  });
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});

--- a/desktop/native/hardwareRuntime.ts
+++ b/desktop/native/hardwareRuntime.ts
@@ -1,0 +1,56 @@
+import type { ConnectDeviceRequest, HardwareDevice, RuntimeStatus, SendFrameRequest } from '../ipc/contracts';
+
+const mockDevices: HardwareDevice[] = [
+  { id: 'dmx-usb-001', name: 'USB DMX Interface', protocol: 'dmx', online: true },
+  { id: 'artnet-node-01', name: 'Art-Net Node #1', protocol: 'artnet', online: true },
+  { id: 'osc-bridge-01', name: 'OSC Bridge', protocol: 'osc', online: true }
+];
+
+export class HardwareRuntime {
+  private status: RuntimeStatus = {
+    ready: true,
+    connectedDeviceId: null,
+    protocol: null
+  };
+
+  listDevices(): HardwareDevice[] {
+    return mockDevices;
+  }
+
+  connectDevice(request: ConnectDeviceRequest): RuntimeStatus {
+    const device = mockDevices.find((d) => d.id === request.deviceId);
+    if (!device) {
+      throw new Error(`Unknown device: ${request.deviceId}`);
+    }
+
+    this.status = {
+      ready: true,
+      connectedDeviceId: device.id,
+      protocol: device.protocol
+    };
+
+    return this.status;
+  }
+
+  disconnectDevice(): RuntimeStatus {
+    this.status = {
+      ...this.status,
+      connectedDeviceId: null,
+      protocol: null
+    };
+    return this.status;
+  }
+
+  sendFrame(request: SendFrameRequest): void {
+    if (!this.status.connectedDeviceId) {
+      throw new Error('No hardware device connected.');
+    }
+
+    // NOTE: Protocol adapters (DMX/Art-Net/OSC) must remain in this native layer.
+    void request;
+  }
+
+  getStatus(): RuntimeStatus {
+    return this.status;
+  }
+}

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "lightai-pro-desktop",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "main": "main.ts",
+  "scripts": {
+    "dev": "electron .",
+    "build": "echo \"Configure ta chaine de build desktop (electron-builder/tauri)\""
+  },
+  "devDependencies": {
+    "electron": "^31.7.7"
+  }
+}

--- a/desktop/preload.ts
+++ b/desktop/preload.ts
@@ -1,0 +1,13 @@
+import { contextBridge, ipcRenderer } from 'electron';
+import { ipcChannels } from './ipc/contracts';
+import type { NativeIpcApi } from './ipc/contracts';
+
+const api: NativeIpcApi = {
+  listDevices: () => ipcRenderer.invoke(ipcChannels.listDevices),
+  connectDevice: (request) => ipcRenderer.invoke(ipcChannels.connectDevice, request),
+  disconnectDevice: () => ipcRenderer.invoke(ipcChannels.disconnectDevice),
+  sendFrame: (request) => ipcRenderer.invoke(ipcChannels.sendFrame, request),
+  getRuntimeStatus: () => ipcRenderer.invoke(ipcChannels.runtimeStatus)
+};
+
+contextBridge.exposeInMainWorld('lightAiNative', api);

--- a/desktop/tsconfig.json
+++ b/desktop/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node", "electron"]
+  },
+  "include": ["./**/*.ts"]
+}

--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -1,0 +1,51 @@
+# Architecture runtime (UI web + shell natif)
+
+## Objectif
+
+L'interface React reste une UI pure (rendu + interactions). Tout accès matériel et protocoles (DMX/Art-Net/OSC, discovery device, émission de trames) est exécuté uniquement dans le runtime natif (`desktop/`).
+
+## Structure
+
+```text
+src/                      # UI React (sandbox navigateur)
+  lib/runtimeClient.ts    # Client IPC vers le runtime natif
+
+desktop/
+  main.ts                 # Process principal (Electron)
+  preload.ts              # Bridge sécurisé vers le renderer
+  ipc/contracts.ts        # Contrats IPC stricts + validateurs
+  ipc/handlers.ts         # Enregistrement handlers IPC
+  native/hardwareRuntime.ts # Logique hardware/protocoles native
+```
+
+## Frontière de sécurité
+
+1. **UI React**: n'accède jamais directement au hardware ni aux protocoles réseau de contrôle lumière.
+2. **Preload**: expose seulement une API minimale (`window.lightAiNative`) via `contextBridge`.
+3. **IPC contracts**: types + assertions runtime pour valider tous les payloads entrants.
+4. **Native runtime**: unique endroit autorisé pour les opérations hardware/protocoles.
+
+## Contrat IPC
+
+Le contrat partagé est défini dans `desktop/ipc/contracts.ts`.
+
+Canaux supportés:
+- `runtime:list-devices`
+- `runtime:connect-device`
+- `runtime:disconnect-device`
+- `runtime:send-frame`
+- `runtime:status`
+
+Chaque payload entrant est validé (`assertConnectDeviceRequest`, `assertSendFrameRequest`) avant d'atteindre la logique native.
+
+## Scripts
+
+Depuis la racine:
+- `npm run desktop:dev` : lance le shell desktop en mode développement.
+- `npm run desktop:build` : point d'entrée build packaging desktop.
+
+## Évolution recommandée
+
+- Remplacer le runtime mock `hardwareRuntime.ts` par des adapters réels DMX/Art-Net/OSC.
+- Ajouter des tests d'intégration IPC (payload invalide, reconnexion, latence).
+- Signer/versionner explicitement le contrat IPC pour éviter les régressions UI/runtime.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "desktop:dev": "npm run dev --prefix desktop",
+    "desktop:build": "npm run build --prefix desktop"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.39.3",

--- a/src/lib/runtimeClient.ts
+++ b/src/lib/runtimeClient.ts
@@ -1,0 +1,37 @@
+import type {
+  ConnectDeviceRequest,
+  HardwareDevice,
+  NativeIpcApi,
+  RuntimeStatus,
+  SendFrameRequest
+} from '../../desktop/ipc/contracts';
+
+const fallbackStatus: RuntimeStatus = {
+  ready: false,
+  connectedDeviceId: null,
+  protocol: null
+};
+
+const unavailableError =
+  'Native runtime unavailable. Start the desktop shell to access hardware protocols.';
+
+function getNativeApi(): NativeIpcApi {
+  if (!window.lightAiNative) {
+    throw new Error(unavailableError);
+  }
+  return window.lightAiNative;
+}
+
+export const runtimeClient = {
+  listDevices: async (): Promise<HardwareDevice[]> => getNativeApi().listDevices(),
+  connectDevice: async (request: ConnectDeviceRequest): Promise<RuntimeStatus> =>
+    getNativeApi().connectDevice(request),
+  disconnectDevice: async (): Promise<RuntimeStatus> => getNativeApi().disconnectDevice(),
+  sendFrame: async (request: SendFrameRequest): Promise<void> => getNativeApi().sendFrame(request),
+  getRuntimeStatus: async (): Promise<RuntimeStatus> => {
+    if (!window.lightAiNative) {
+      return fallbackStatus;
+    }
+    return window.lightAiNative.getRuntimeStatus();
+  }
+};

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+import type { NativeIpcApi } from '../desktop/ipc/contracts';
+
+declare global {
+  interface Window {
+    lightAiNative?: NativeIpcApi;
+  }
+}


### PR DESCRIPTION
### Motivation
- Separate the React UI from hardware/protocol logic so browser code never touches DMX/Art-Net/OSC or device sockets.
- Provide a minimal, secure IPC surface and runtime-native adapters to centralize protocol handling and reduce attack surface.
- Scaffold a desktop shell to enable a native runtime for hardware access and future packaging (Electron/Tauri).

### Description
- Add a `desktop/` runtime with `main.ts`, `preload.ts`, a mock native runtime `native/hardwareRuntime.ts`, IPC handlers `ipc/handlers.ts`, strict shared contracts `ipc/contracts.ts`, `tsconfig.json` and a `desktop/package.json` scaffold.
- Add a browser-side client `src/lib/runtimeClient.ts` and global typing in `src/vite-env.d.ts` that consume the secured `window.lightAiNative` API exposed by the preload script.
- Add root npm scripts `desktop:dev` and `desktop:build` in `package.json` to run the desktop shell from the repository root.
- Document the architecture, security boundary, IPC channels and recommended evolution in `docs/architecture/runtime.md`.

### Testing
- Ran `npm run build` which completed successfully and produced the production build.
- Ran `npm run lint` which failed due to pre-existing ESLint/type issues in unrelated UI files (`no-explicit-any`, missing hook deps, etc.).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d316bd8688832abeb8eddcaa717f4f)