### PR TITLE
feat: add standalone lighting engine core module

### DIFF
--- a/src/core/lighting-engine/engine.ts
+++ b/src/core/lighting-engine/engine.ts
@@ -1,0 +1,31 @@
+import { applyScene, setChannel, startCue, stopCue, tickCue } from './state';
+import { ShowState } from './types';
+
+export type LightingCommand =
+  | { type: 'setChannel'; universeId: string; channel: number; value: number }
+  | { type: 'applyScene'; sceneId: string }
+  | { type: 'startCue'; cueId: string; nowMs: number }
+  | { type: 'stopCue' }
+  | { type: 'tick'; nowMs: number };
+
+export const reduceLightingCommand = (
+  state: ShowState,
+  command: LightingCommand,
+): ShowState => {
+  switch (command.type) {
+    case 'setChannel':
+      return setChannel(state, command.universeId, command.channel, command.value);
+    case 'applyScene':
+      return applyScene(state, command.sceneId);
+    case 'startCue':
+      return startCue(state, command.cueId, command.nowMs);
+    case 'stopCue':
+      return stopCue(state);
+    case 'tick':
+      return tickCue(state, command.nowMs);
+    default: {
+      const exhaustive: never = command;
+      return exhaustive;
+    }
+  }
+};

--- a/src/core/lighting-engine/index.ts
+++ b/src/core/lighting-engine/index.ts
@@ -1,0 +1,5 @@
+export * from './types';
+export * from './state';
+export * from './engine';
+export * from './scheduler';
+export * from './serialization';

--- a/src/core/lighting-engine/scheduler.ts
+++ b/src/core/lighting-engine/scheduler.ts
@@ -1,0 +1,92 @@
+export interface FrameSchedulerDependencies {
+  now: () => number;
+  schedule: (cb: () => void, delayMs: number) => unknown;
+  cancel: (token: unknown) => void;
+}
+
+export interface FrameSchedulerOptions {
+  tickMs: number;
+  onTick: (nowMs: number) => void;
+  deps?: Partial<FrameSchedulerDependencies>;
+}
+
+const defaultDeps: FrameSchedulerDependencies = {
+  now: () => Date.now(),
+  schedule: (cb, delayMs) => setTimeout(cb, delayMs),
+  cancel: (token) => clearTimeout(token as ReturnType<typeof setTimeout>),
+};
+
+/**
+ * Fixed tick scheduler intentionally decoupled from React rendering.
+ * It can be unit-tested by injecting fake clock/scheduler dependencies.
+ */
+export class FrameScheduler {
+  private readonly tickMs: number;
+  private readonly onTick: (nowMs: number) => void;
+  private readonly deps: FrameSchedulerDependencies;
+  private timerToken: unknown | null = null;
+  private running = false;
+  private nextTickAt = 0;
+
+  constructor(options: FrameSchedulerOptions) {
+    this.tickMs = Math.max(1, Math.floor(options.tickMs));
+    this.onTick = options.onTick;
+    this.deps = {
+      ...defaultDeps,
+      ...options.deps,
+    };
+  }
+
+  start(startAtMs = this.deps.now()): void {
+    if (this.running) {
+      return;
+    }
+
+    this.running = true;
+    this.nextTickAt = startAtMs + this.tickMs;
+    this.scheduleNext();
+  }
+
+  stop(): void {
+    if (!this.running) {
+      return;
+    }
+
+    this.running = false;
+    if (this.timerToken !== null) {
+      this.deps.cancel(this.timerToken);
+      this.timerToken = null;
+    }
+  }
+
+  isRunning(): boolean {
+    return this.running;
+  }
+
+  step(nowMs = this.deps.now()): number {
+    if (this.nextTickAt === 0) {
+      this.nextTickAt = nowMs;
+    }
+
+    let tickCount = 0;
+    while (nowMs >= this.nextTickAt) {
+      this.onTick(this.nextTickAt);
+      this.nextTickAt += this.tickMs;
+      tickCount += 1;
+    }
+
+    return tickCount;
+  }
+
+  private scheduleNext(): void {
+    if (!this.running) {
+      return;
+    }
+
+    const nowMs = this.deps.now();
+    this.step(nowMs);
+
+    const delayMs = Math.max(0, this.nextTickAt - this.deps.now());
+    this.timerToken = this.deps.schedule(() => this.scheduleNext(), delayMs);
+  }
+}

--- a/src/core/lighting-engine/serialization.ts
+++ b/src/core/lighting-engine/serialization.ts
@@ -1,0 +1,31 @@
+import { ShowState } from './types';
+
+interface PersistedShowState {
+  version: 1;
+  state: ShowState;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const assertValidPayload = (value: unknown): asserts value is PersistedShowState => {
+  if (!isRecord(value) || value.version !== 1 || !('state' in value)) {
+    throw new Error('Invalid serialized show state payload');
+  }
+
+  if (!isRecord(value.state)) {
+    throw new Error('Serialized payload state is invalid');
+  }
+};
+
+export const serializeShowState = (state: ShowState): string =>
+  JSON.stringify({
+    version: 1,
+    state,
+  } satisfies PersistedShowState);
+
+export const deserializeShowState = (json: string): ShowState => {
+  const payload = JSON.parse(json) as unknown;
+  assertValidPayload(payload);
+  return payload.state;
+};

--- a/src/core/lighting-engine/state.ts
+++ b/src/core/lighting-engine/state.ts
@@ -1,0 +1,187 @@
+import {
+  Cue,
+  DEFAULT_UNIVERSE_SIZE,
+  ShowState,
+  Universe,
+  type ChannelValue,
+} from './types';
+
+const clampChannelValue = (value: number): ChannelValue =>
+  Math.max(0, Math.min(255, Math.round(value)));
+
+const assertUniverseChannel = (universe: Universe, channel: number) => {
+  if (!Number.isInteger(channel) || channel < 1 || channel > universe.size) {
+    throw new Error(
+      `Channel ${channel} is outside universe "${universe.id}" range 1..${universe.size}`,
+    );
+  }
+};
+
+const assertUniverseExists = (state: ShowState, universeId: string): Universe => {
+  const universe = state.universes[universeId];
+  if (!universe) {
+    throw new Error(`Universe "${universeId}" not found`);
+  }
+  return universe;
+};
+
+const getCueStepDuration = (cue: Cue, stepIndex: number): number => {
+  const step = cue.steps[stepIndex];
+  if (!step) {
+    return 0;
+  }
+  return Math.max(0, step.holdMs) + Math.max(0, step.fadeMs);
+};
+
+const getSceneValuesMap = (state: ShowState, sceneId: string): Map<string, ChannelValue> => {
+  const scene = state.scenes[sceneId];
+  if (!scene) {
+    throw new Error(`Scene "${sceneId}" not found`);
+  }
+
+  const values = new Map<string, ChannelValue>();
+  for (const value of scene.values) {
+    const universe = assertUniverseExists(state, value.universeId);
+    assertUniverseChannel(universe, value.channel);
+    values.set(`${value.universeId}:${value.channel}`, clampChannelValue(value.value));
+  }
+
+  return values;
+};
+
+export const createShowState = (): ShowState => ({
+  fixtures: {},
+  universes: {
+    default: {
+      id: 'default',
+      name: 'Default Universe',
+      size: DEFAULT_UNIVERSE_SIZE,
+      channels: {},
+    },
+  },
+  scenes: {},
+  cues: {},
+  activeCue: null,
+  currentSceneId: null,
+  tick: 0,
+});
+
+export const setChannel = (
+  state: ShowState,
+  universeId: string,
+  channel: number,
+  value: number,
+): ShowState => {
+  const universe = assertUniverseExists(state, universeId);
+  assertUniverseChannel(universe, channel);
+
+  return {
+    ...state,
+    universes: {
+      ...state.universes,
+      [universeId]: {
+        ...universe,
+        channels: {
+          ...universe.channels,
+          [channel]: clampChannelValue(value),
+        },
+      },
+    },
+  };
+};
+
+export const applyScene = (state: ShowState, sceneId: string): ShowState => {
+  const values = getSceneValuesMap(state, sceneId);
+
+  let nextState = state;
+  for (const [key, value] of values.entries()) {
+    const [universeId, channelAsString] = key.split(':');
+    nextState = setChannel(nextState, universeId, Number(channelAsString), value);
+  }
+
+  return {
+    ...nextState,
+    currentSceneId: sceneId,
+  };
+};
+
+export const startCue = (state: ShowState, cueId: string, nowMs: number): ShowState => {
+  const cue = state.cues[cueId];
+  if (!cue) {
+    throw new Error(`Cue "${cueId}" not found`);
+  }
+  if (cue.steps.length === 0) {
+    throw new Error(`Cue "${cueId}" has no steps`);
+  }
+
+  const stateWithFirstStep = applyScene(state, cue.steps[0].sceneId);
+
+  return {
+    ...stateWithFirstStep,
+    activeCue: {
+      cueId,
+      stepIndex: 0,
+      startedAtMs: nowMs,
+      stepStartedAtMs: nowMs,
+    },
+  };
+};
+
+export const stopCue = (state: ShowState): ShowState => ({
+  ...state,
+  activeCue: null,
+});
+
+export const tickCue = (state: ShowState, nowMs: number): ShowState => {
+  if (!state.activeCue) {
+    return {
+      ...state,
+      tick: state.tick + 1,
+    };
+  }
+
+  const cue = state.cues[state.activeCue.cueId];
+  if (!cue) {
+    return stopCue({ ...state, tick: state.tick + 1 });
+  }
+
+  const duration = getCueStepDuration(cue, state.activeCue.stepIndex);
+  if (duration <= 0 || nowMs - state.activeCue.stepStartedAtMs < duration) {
+    return {
+      ...state,
+      tick: state.tick + 1,
+    };
+  }
+
+  const nextStepIndex = state.activeCue.stepIndex + 1;
+  if (nextStepIndex < cue.steps.length) {
+    const withScene = applyScene(state, cue.steps[nextStepIndex].sceneId);
+    return {
+      ...withScene,
+      activeCue: {
+        ...state.activeCue,
+        stepIndex: nextStepIndex,
+        stepStartedAtMs: nowMs,
+      },
+      tick: state.tick + 1,
+    };
+  }
+
+  if (!cue.loop) {
+    return {
+      ...stopCue(state),
+      tick: state.tick + 1,
+    };
+  }
+
+  const withLoopFirstScene = applyScene(state, cue.steps[0].sceneId);
+  return {
+    ...withLoopFirstScene,
+    activeCue: {
+      ...state.activeCue,
+      stepIndex: 0,
+      stepStartedAtMs: nowMs,
+    },
+    tick: state.tick + 1,
+  };
+};

--- a/src/core/lighting-engine/types.ts
+++ b/src/core/lighting-engine/types.ts
@@ -1,0 +1,60 @@
+export type ChannelValue = number;
+
+export interface Fixture {
+  id: string;
+  name: string;
+  universeId: string;
+  address: number;
+  channels: number;
+}
+
+export interface Universe {
+  id: string;
+  name: string;
+  size: number;
+  channels: Record<number, ChannelValue>;
+}
+
+export interface SceneValue {
+  universeId: string;
+  channel: number;
+  value: ChannelValue;
+}
+
+export interface Scene {
+  id: string;
+  name: string;
+  values: SceneValue[];
+}
+
+export interface CueStep {
+  sceneId: string;
+  holdMs: number;
+  fadeMs: number;
+}
+
+export interface Cue {
+  id: string;
+  name: string;
+  steps: CueStep[];
+  loop: boolean;
+}
+
+export interface ActiveCueState {
+  cueId: string;
+  stepIndex: number;
+  startedAtMs: number;
+  stepStartedAtMs: number;
+}
+
+export interface ShowState {
+  fixtures: Record<string, Fixture>;
+  universes: Record<string, Universe>;
+  scenes: Record<string, Scene>;
+  cues: Record<string, Cue>;
+  activeCue: ActiveCueState | null;
+  currentSceneId: string | null;
+  tick: number;
+}
+
+export const DEFAULT_UNIVERSE_SIZE = 512;


### PR DESCRIPTION
### Motivation
- Provide a UI-independent, testable lighting engine core that models DMX fixtures, universes, scenes, cues and the global show state. 
- Expose atomic, immutable state transitions and a deterministic tick scheduler so show logic can be driven from non-React hosts or unit tests.

### Description
- Added domain types in `src/core/lighting-engine/types.ts` for `Fixture`, `Universe`, `Scene`, `Cue`, `ActiveCueState`, and `ShowState` and the `DEFAULT_UNIVERSE_SIZE` constant. 
- Implemented pure state logic in `src/core/lighting-engine/state.ts` including `setChannel`, `applyScene`, `startCue`, `stopCue`, `tickCue`, bounds checks and `createShowState`. 
- Implemented a fixed-tick `FrameScheduler` in `src/core/lighting-engine/scheduler.ts` with injectable `now/schedule/cancel` dependencies to allow deterministic unit testing. 
- Added a command reducer `reduceLightingCommand` in `src/core/lighting-engine/engine.ts` to apply typed commands (`setChannel`, `applyScene`, `startCue`, `stopCue`, `tick`) as IO-pure operations. 
- Added versioned show state persistence helpers `serializeShowState` and `deserializeShowState` in `src/core/lighting-engine/serialization.ts` and exported the module public API from `src/core/lighting-engine/index.ts`.

### Testing
- Ran a production build with `npm run build` which completed successfully. 
- Linted only the new module with `npx eslint src/core/lighting-engine` which passed without errors. 
- Ran full lint with `npm run lint` which failed due to pre-existing lint errors outside the new module (errors live in `src/components/*` and `src/lib/*`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d319bac888832a96f8a6711c927af9)