### PR TITLE
Ajouter drivers de sortie lumière configurables (Art‑Net / DMX / OSC / Simulator)

### DIFF
--- a/src/core/lighting-engine/index.ts
+++ b/src/core/lighting-engine/index.ts
@@ -3,3 +3,5 @@ export * from './state';
 export * from './engine';
 export * from './scheduler';
 export * from './serialization';
+
+export * from '../protocols';

--- a/src/core/lighting-engine/serialization.ts
+++ b/src/core/lighting-engine/serialization.ts
@@ -1,4 +1,5 @@
 import { ShowState } from './types';
+import { defaultShowOutputConfig } from '../protocols/types';
 
 interface PersistedShowState {
   version: 1;
@@ -27,5 +28,9 @@ export const serializeShowState = (state: ShowState): string =>
 export const deserializeShowState = (json: string): ShowState => {
   const payload = JSON.parse(json) as unknown;
   assertValidPayload(payload);
-  return payload.state;
+
+  return {
+    ...payload.state,
+    output: payload.state.output ?? defaultShowOutputConfig,
+  };
 };

--- a/src/core/lighting-engine/state.ts
+++ b/src/core/lighting-engine/state.ts
@@ -5,6 +5,7 @@ import {
   Universe,
   type ChannelValue,
 } from './types';
+import { defaultShowOutputConfig } from '../protocols/types';
 
 const clampChannelValue = (value: number): ChannelValue =>
   Math.max(0, Math.min(255, Math.round(value)));
@@ -64,6 +65,7 @@ export const createShowState = (): ShowState => ({
   activeCue: null,
   currentSceneId: null,
   tick: 0,
+  output: defaultShowOutputConfig,
 });
 
 export const setChannel = (

--- a/src/core/lighting-engine/types.ts
+++ b/src/core/lighting-engine/types.ts
@@ -1,3 +1,5 @@
+import type { ShowOutputConfig } from '../protocols/types';
+
 export type ChannelValue = number;
 
 export interface Fixture {
@@ -55,6 +57,7 @@ export interface ShowState {
   activeCue: ActiveCueState | null;
   currentSceneId: string | null;
   tick: number;
+  output: ShowOutputConfig;
 }
 
 export const DEFAULT_UNIVERSE_SIZE = 512;

--- a/src/core/protocols/drivers/artnet/index.ts
+++ b/src/core/protocols/drivers/artnet/index.ts
@@ -1,0 +1,78 @@
+import type { ArtNetDriverConfig, LightingOutputDriver, UniverseFrame } from '../../types';
+
+const ARTNET_HEADER = 'Art-Net\u0000';
+const OP_OUTPUT = 0x5000;
+const PROTOCOL_VERSION = 14;
+const DEFAULT_ARTNET_PORT = 6454;
+
+export interface ArtNetTransport {
+  send(packet: Uint8Array, port: number, host: string): Promise<void>;
+}
+
+export interface ArtNetDriverDependencies {
+  transport: ArtNetTransport;
+}
+
+const buildArtNetPacket = (universe: number, frame: UniverseFrame): Uint8Array => {
+  const safeUniverse = Math.max(0, Math.min(0x7fff, Math.floor(universe)));
+  const length = Math.max(2, Math.min(512, frame.length));
+  const evenLength = length % 2 === 0 ? length : length + 1;
+  const packet = new Uint8Array(18 + evenLength);
+
+  for (let index = 0; index < ARTNET_HEADER.length; index += 1) {
+    packet[index] = ARTNET_HEADER.charCodeAt(index);
+  }
+
+  packet[8] = OP_OUTPUT & 0xff;
+  packet[9] = (OP_OUTPUT >> 8) & 0xff;
+  packet[10] = (PROTOCOL_VERSION >> 8) & 0xff;
+  packet[11] = PROTOCOL_VERSION & 0xff;
+  packet[12] = 0;
+  packet[13] = 0;
+  packet[14] = safeUniverse & 0xff;
+  packet[15] = (safeUniverse >> 8) & 0xff;
+  packet[16] = (evenLength >> 8) & 0xff;
+  packet[17] = evenLength & 0xff;
+
+  for (let index = 0; index < evenLength; index += 1) {
+    packet[18 + index] = Math.max(0, Math.min(255, Math.round(frame[index] ?? 0)));
+  }
+
+  return packet;
+};
+
+export class ArtNetOutputDriver implements LightingOutputDriver {
+  readonly metadata = {
+    kind: 'artnet' as const,
+    name: 'Art-Net output driver',
+  };
+
+  constructor(
+    private readonly config: ArtNetDriverConfig,
+    private readonly dependencies: ArtNetDriverDependencies,
+  ) {}
+
+  async connect(): Promise<void> {
+    // UDP transport can lazily send without explicit handshake.
+  }
+
+  async disconnect(): Promise<void> {
+    // Stateless transport, nothing to tear down.
+  }
+
+  async sendUniverse(universe: number, frame: UniverseFrame): Promise<void> {
+    const packet = buildArtNetPacket(universe, frame);
+    await this.dependencies.transport.send(
+      packet,
+      this.config.port ?? DEFAULT_ARTNET_PORT,
+      this.config.host,
+    );
+  }
+
+  async sendUniverses(universes: Readonly<Record<number, UniverseFrame>>): Promise<void> {
+    const universesAsEntries = Object.entries(universes);
+    for (const [universeAsString, frame] of universesAsEntries) {
+      await this.sendUniverse(Number(universeAsString), frame);
+    }
+  }
+}

--- a/src/core/protocols/drivers/dmx/index.ts
+++ b/src/core/protocols/drivers/dmx/index.ts
@@ -1,0 +1,66 @@
+import type { DmxDriverConfig, LightingOutputDriver, UniverseFrame } from '../../types';
+
+export interface DmxUsbInterface {
+  readonly id: string;
+  open(): Promise<void>;
+  close(): Promise<void>;
+  writeUniverse(frame: UniverseFrame): Promise<void>;
+}
+
+export interface DmxDriverDependencies {
+  interfaces: ReadonlyArray<DmxUsbInterface>;
+}
+
+export class DmxUsbOutputDriver implements LightingOutputDriver {
+  readonly metadata = {
+    kind: 'dmx' as const,
+    name: 'DMX USB output driver',
+  };
+
+  private readonly interfacesById: Readonly<Record<string, DmxUsbInterface>>;
+
+  constructor(
+    private readonly config: DmxDriverConfig,
+    dependencies: DmxDriverDependencies,
+  ) {
+    this.interfacesById = Object.fromEntries(
+      dependencies.interfaces.map((dmxInterface) => [dmxInterface.id, dmxInterface]),
+    );
+  }
+
+  async connect(): Promise<void> {
+    for (const dmxInterface of Object.values(this.interfacesById)) {
+      await dmxInterface.open();
+    }
+  }
+
+  async disconnect(): Promise<void> {
+    for (const dmxInterface of Object.values(this.interfacesById)) {
+      await dmxInterface.close();
+    }
+  }
+
+  async sendUniverse(universe: number, frame: UniverseFrame): Promise<void> {
+    const binding = this.config.universeBindings?.find((candidate) => candidate.universe === universe);
+    const fallbackInterfaceId = this.config.interfaces?.[0];
+    const targetInterfaceId = binding?.interfaceId ?? fallbackInterfaceId;
+
+    if (!targetInterfaceId) {
+      return;
+    }
+
+    const dmxInterface = this.interfacesById[targetInterfaceId];
+    if (!dmxInterface) {
+      throw new Error(`DMX interface "${targetInterfaceId}" unavailable`);
+    }
+
+    await dmxInterface.writeUniverse(frame);
+  }
+
+  async sendUniverses(universes: Readonly<Record<number, UniverseFrame>>): Promise<void> {
+    const universesAsEntries = Object.entries(universes);
+    for (const [universeAsString, frame] of universesAsEntries) {
+      await this.sendUniverse(Number(universeAsString), frame);
+    }
+  }
+}

--- a/src/core/protocols/drivers/osc/index.ts
+++ b/src/core/protocols/drivers/osc/index.ts
@@ -1,0 +1,64 @@
+import type { LightingOutputDriver, OscDriverConfig, UniverseFrame } from '../../types';
+
+export interface OscMessage {
+  readonly address: string;
+  readonly args: ReadonlyArray<number>;
+}
+
+export interface OscTransport {
+  send(targetUrl: string, message: OscMessage): Promise<void>;
+}
+
+export interface OscDriverDependencies {
+  transport: OscTransport;
+}
+
+const DEFAULT_OSC_ADDRESS = '/lighting/universe';
+
+const getAddressForUniverse = (config: OscDriverConfig, universe: number): string => {
+  const mappedAddress = config.universeAddressMap?.[universe];
+  if (mappedAddress) {
+    return mappedAddress;
+  }
+  if (config.defaultAddress) {
+    return config.defaultAddress;
+  }
+  return `${DEFAULT_OSC_ADDRESS}/${universe}`;
+};
+
+export class OscOutputDriver implements LightingOutputDriver {
+  readonly metadata = {
+    kind: 'osc' as const,
+    name: 'OSC output driver',
+  };
+
+  constructor(
+    private readonly config: OscDriverConfig,
+    private readonly dependencies: OscDriverDependencies,
+  ) {}
+
+  async connect(): Promise<void> {
+    // No-op by default; transport can open lazily.
+  }
+
+  async disconnect(): Promise<void> {
+    // No-op by default.
+  }
+
+  async sendUniverse(universe: number, frame: UniverseFrame): Promise<void> {
+    const address = getAddressForUniverse(this.config, universe);
+    const message: OscMessage = {
+      address,
+      args: frame.map((value) => Math.max(0, Math.min(255, Math.round(value)))),
+    };
+
+    await this.dependencies.transport.send(this.config.targetUrl, message);
+  }
+
+  async sendUniverses(universes: Readonly<Record<number, UniverseFrame>>): Promise<void> {
+    const universesAsEntries = Object.entries(universes);
+    for (const [universeAsString, frame] of universesAsEntries) {
+      await this.sendUniverse(Number(universeAsString), frame);
+    }
+  }
+}

--- a/src/core/protocols/drivers/simulator/index.ts
+++ b/src/core/protocols/drivers/simulator/index.ts
@@ -1,0 +1,68 @@
+import type { LightingOutputDriver, SimulatorDriverConfig, UniverseFrame } from '../../types';
+
+export interface SimulatorFrameEvent {
+  readonly universe: number;
+  readonly frame: UniverseFrame;
+  readonly atMs: number;
+}
+
+export interface SimulatorDriverDependencies {
+  onFrame?: (event: SimulatorFrameEvent) => void;
+  now?: () => number;
+}
+
+export class SimulatorOutputDriver implements LightingOutputDriver {
+  readonly metadata = {
+    kind: 'simulator' as const,
+    name: 'Simulator output driver',
+  };
+
+  readonly history: SimulatorFrameEvent[] = [];
+
+  private readonly now: () => number;
+
+  constructor(
+    private readonly config: SimulatorDriverConfig,
+    private readonly dependencies: SimulatorDriverDependencies = {},
+  ) {
+    this.now = dependencies.now ?? (() => Date.now());
+  }
+
+  async connect(): Promise<void> {
+    // No-op; simulation starts immediately.
+  }
+
+  async disconnect(): Promise<void> {
+    // No-op.
+  }
+
+  async sendUniverse(universe: number, frame: UniverseFrame): Promise<void> {
+    const latency = Math.max(0, this.config.latencyMs ?? 0);
+    if (latency > 0) {
+      await new Promise((resolve) => {
+        setTimeout(resolve, latency);
+      });
+    }
+
+    const event: SimulatorFrameEvent = {
+      universe,
+      frame,
+      atMs: this.now(),
+    };
+
+    this.history.push(event);
+
+    if (this.config.logFrames) {
+      console.debug('[simulator-driver]', event);
+    }
+
+    this.dependencies.onFrame?.(event);
+  }
+
+  async sendUniverses(universes: Readonly<Record<number, UniverseFrame>>): Promise<void> {
+    const universesAsEntries = Object.entries(universes);
+    for (const [universeAsString, frame] of universesAsEntries) {
+      await this.sendUniverse(Number(universeAsString), frame);
+    }
+  }
+}

--- a/src/core/protocols/index.ts
+++ b/src/core/protocols/index.ts
@@ -1,0 +1,6 @@
+export * from './types';
+export * from './selector';
+export * from './drivers/artnet';
+export * from './drivers/dmx';
+export * from './drivers/osc';
+export * from './drivers/simulator';

--- a/src/core/protocols/selector.ts
+++ b/src/core/protocols/selector.ts
@@ -1,0 +1,142 @@
+import type { ShowState, Universe } from '../lighting-engine/types';
+import { ArtNetOutputDriver, type ArtNetDriverDependencies } from './drivers/artnet';
+import { DmxUsbOutputDriver, type DmxDriverDependencies } from './drivers/dmx';
+import { OscOutputDriver, type OscDriverDependencies } from './drivers/osc';
+import {
+  SimulatorOutputDriver,
+  type SimulatorDriverDependencies,
+} from './drivers/simulator';
+import {
+  defaultShowOutputConfig,
+  type DriverKind,
+  type LightingOutputDriver,
+  type ShowOutputConfig,
+  type UniverseFrame,
+} from './types';
+
+export interface LightingDriverFactoryDependencies {
+  artnet?: ArtNetDriverDependencies;
+  dmx?: DmxDriverDependencies;
+  osc?: OscDriverDependencies;
+  simulator?: SimulatorDriverDependencies;
+}
+
+const getConfigForDriver = (config: ShowOutputConfig, kind: DriverKind) => {
+  switch (kind) {
+    case 'artnet':
+      return config.artnet;
+    case 'dmx':
+      return config.dmx;
+    case 'osc':
+      return config.osc;
+    case 'simulator':
+      return config.simulator;
+    default: {
+      const exhaustive: never = kind;
+      return exhaustive;
+    }
+  }
+};
+
+const universeToFrame = (universe: Universe): UniverseFrame => {
+  const frame: number[] = [];
+  for (let channel = 1; channel <= universe.size; channel += 1) {
+    frame.push(universe.channels[channel] ?? 0);
+  }
+  return frame;
+};
+
+export const showStateToUniverseFrames = (
+  showState: Pick<ShowState, 'universes'>,
+): Readonly<Record<number, UniverseFrame>> => {
+  const frames: Record<number, UniverseFrame> = {};
+
+  for (const [universeId, universe] of Object.entries(showState.universes)) {
+    const universeIndex = Number(universeId) || 0;
+    frames[universeIndex] = universeToFrame(universe);
+  }
+
+  return frames;
+};
+
+export const createLightingOutputDriver = (
+  config: ShowOutputConfig,
+  dependencies: LightingDriverFactoryDependencies = {},
+): LightingOutputDriver => {
+  const { activeDriver } = config;
+
+  switch (activeDriver) {
+    case 'artnet': {
+      if (!config.artnet) {
+        throw new Error('Art-Net driver selected but not configured');
+      }
+      if (!dependencies.artnet) {
+        throw new Error('Art-Net dependencies are required to create the driver');
+      }
+      return new ArtNetOutputDriver(config.artnet, dependencies.artnet);
+    }
+    case 'dmx': {
+      if (!config.dmx) {
+        throw new Error('DMX driver selected but not configured');
+      }
+      if (!dependencies.dmx) {
+        throw new Error('DMX dependencies are required to create the driver');
+      }
+      return new DmxUsbOutputDriver(config.dmx, dependencies.dmx);
+    }
+    case 'osc': {
+      if (!config.osc) {
+        throw new Error('OSC driver selected but not configured');
+      }
+      if (!dependencies.osc) {
+        throw new Error('OSC dependencies are required to create the driver');
+      }
+      return new OscOutputDriver(config.osc, dependencies.osc);
+    }
+    case 'simulator': {
+      return new SimulatorOutputDriver(
+        config.simulator ?? defaultShowOutputConfig.simulator ?? { kind: 'simulator' },
+        dependencies.simulator,
+      );
+    }
+    default: {
+      const exhaustive: never = activeDriver;
+      return exhaustive;
+    }
+  }
+};
+
+export class LightingOutputRouter {
+  private driver: LightingOutputDriver | null = null;
+
+  constructor(private readonly dependencies: LightingDriverFactoryDependencies = {}) {}
+
+  async setConfiguration(config: ShowOutputConfig): Promise<void> {
+    if (this.driver) {
+      await this.driver.disconnect();
+    }
+
+    this.driver = createLightingOutputDriver(config, this.dependencies);
+    await this.driver.connect();
+  }
+
+  async applyState(showState: ShowState): Promise<void> {
+    if (!this.driver) {
+      const config = showState.output ?? defaultShowOutputConfig;
+      await this.setConfiguration(config);
+    }
+
+    const frames = showStateToUniverseFrames(showState);
+    await this.driver?.sendUniverses(frames);
+  }
+
+  getActiveDriver(): LightingOutputDriver | null {
+    return this.driver;
+  }
+}
+
+export const resolveShowOutputConfig = (showState: Pick<ShowState, 'output'>): ShowOutputConfig =>
+  showState.output ?? defaultShowOutputConfig;
+
+export const getActiveDriverConfiguration = (config: ShowOutputConfig) =>
+  getConfigForDriver(config, config.activeDriver);

--- a/src/core/protocols/types.ts
+++ b/src/core/protocols/types.ts
@@ -1,0 +1,64 @@
+export type UniverseFrame = ReadonlyArray<number>;
+
+export type DriverKind = 'artnet' | 'dmx' | 'osc' | 'simulator';
+
+export interface DriverMetadata {
+  readonly kind: DriverKind;
+  readonly name: string;
+}
+
+export interface LightingOutputDriver {
+  readonly metadata: DriverMetadata;
+  connect(): Promise<void>;
+  disconnect(): Promise<void>;
+  sendUniverse(universe: number, frame: UniverseFrame): Promise<void>;
+  sendUniverses(universes: Readonly<Record<number, UniverseFrame>>): Promise<void>;
+}
+
+export interface ArtNetDriverConfig {
+  readonly kind: 'artnet';
+  readonly host: string;
+  readonly port?: number;
+  readonly sourceName?: string;
+}
+
+export interface DmxUniverseBinding {
+  readonly universe: number;
+  readonly interfaceId: string;
+}
+
+export interface DmxDriverConfig {
+  readonly kind: 'dmx';
+  readonly interfaces?: ReadonlyArray<string>;
+  readonly universeBindings?: ReadonlyArray<DmxUniverseBinding>;
+}
+
+export interface OscDriverConfig {
+  readonly kind: 'osc';
+  readonly targetUrl: string;
+  readonly defaultAddress?: string;
+  readonly universeAddressMap?: Readonly<Record<number, string>>;
+}
+
+export interface SimulatorDriverConfig {
+  readonly kind: 'simulator';
+  readonly latencyMs?: number;
+  readonly logFrames?: boolean;
+}
+
+export interface ShowOutputConfig {
+  readonly activeDriver: DriverKind;
+  readonly artnet?: ArtNetDriverConfig;
+  readonly dmx?: DmxDriverConfig;
+  readonly osc?: OscDriverConfig;
+  readonly simulator?: SimulatorDriverConfig;
+}
+
+export const defaultShowOutputConfig: ShowOutputConfig = {
+  activeDriver: 'simulator',
+  simulator: {
+    kind: 'simulator',
+    latencyMs: 0,
+    logFrames: false,
+  },
+};


### PR DESCRIPTION
### Motivation
- Fournir une couche abstraite pour envoyer des trames DMX/OSC/Art‑Net depuis l’application et permettre de changer dynamiquement le backend selon la configuration du show.
- Permettre le développement sans matériel via un driver de simulation réutilisable.

### Description
- Ajout du module `src/core/protocols/` avec l’interface `LightingOutputDriver`, les types de configuration `ShowOutputConfig` et `UniverseFrame`, et `defaultShowOutputConfig` (simulateur par défaut).
- Implémentation de quatre drivers : `drivers/artnet` (construction et envoi de paquets Art‑Net via transport injecté), `drivers/dmx` (abstraction DMX USB + mapping univers→interface), `drivers/osc` (envoi de messages OSC configurables), et `drivers/simulator` (mode simulation avec historique et option de latence/log).
- Ajout d’une factory/routeur (`createLightingOutputDriver`, `LightingOutputRouter`) et de la conversion `showStateToUniverseFrames` pour produire les trames univers à partir du `ShowState`.
- Intégration dans le moteur d’éclairage : `ShowState` reçoit le champ `output`, `createShowState()` initialise la configuration par défaut (simulateur) et la désérialisation injecte `defaultShowOutputConfig` pour maintenir la compatibilité des shows existants; export des protocols depuis `core/lighting-engine`.

### Testing
- `npm run build` a été exécuté et a réussi (build production Vite) ✅.
- `npm run lint` a été exécuté et a échoué avec des erreurs préexistantes hors du périmètre de cette PR (`@typescript-eslint/no-explicit-any`, `@typescript-eslint/no-unused-vars`, et quelques avertissements de hooks), ces erreurs ne sont pas introduites par ce changement ❌.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d31ac6bb40832ab74267e566eb7df3)