### PR TITLE
Add fixture profile registry and patch editor pipeline

### DIFF
--- a/src/core/fixtures/README.md
+++ b/src/core/fixtures/README.md
@@ -1,0 +1,26 @@
+# Fixtures core module
+
+Ce module introduit un format de profil interne inspiré d'Open Fixture Library.
+
+## Format de profil (`lightai.fixture.v1`)
+
+```ts
+interface FixtureProfile {
+  format: 'lightai.fixture.v1';
+  manufacturer: string;
+  model: string;
+  profileId: string;
+  modes: Array<{
+    id: string;
+    name: string;
+    channels: Array<{
+      key: string;
+      name: string;
+      type: 'intensity' | 'color' | 'position' | 'effect' | 'strobe' | 'control' | 'custom';
+      defaultValue?: number;
+    }>;
+  }>;
+}
+```
+
+Le patch editor valide ensuite les collisions d'adresses et les débordements (1..512) avant de produire le mapping final (frames par univers) pour le moteur lumière.

--- a/src/core/fixtures/cache.ts
+++ b/src/core/fixtures/cache.ts
@@ -1,0 +1,13 @@
+import type { FixtureProfile, FixtureProfileCache } from './types';
+
+export class InMemoryFixtureProfileCache implements FixtureProfileCache {
+  private profiles: FixtureProfile[] = [];
+
+  async loadAll(): Promise<ReadonlyArray<FixtureProfile>> {
+    return this.profiles;
+  }
+
+  async saveAll(profiles: ReadonlyArray<FixtureProfile>): Promise<void> {
+    this.profiles = [...profiles];
+  }
+}

--- a/src/core/fixtures/engine-mapper.ts
+++ b/src/core/fixtures/engine-mapper.ts
@@ -1,0 +1,31 @@
+import type { ShowState, Universe } from '../lighting-engine/types';
+import type { PatchRenderMapping } from './types';
+
+const frameToUniverse = (universeId: string, frame: ReadonlyArray<number>): Universe => {
+  const channels: Record<number, number> = {};
+  frame.forEach((value, index) => {
+    const channel = index + 1;
+    if (value !== 0) {
+      channels[channel] = value;
+    }
+  });
+
+  return {
+    id: universeId,
+    name: `Universe ${universeId}`,
+    size: frame.length,
+    channels,
+  };
+};
+
+export const patchRenderMappingToShowStateUniverses = (
+  mapping: PatchRenderMapping,
+): ShowState['universes'] => {
+  const universes: ShowState['universes'] = {};
+
+  for (const [universeIndexAsString, frame] of Object.entries(mapping.universeFrames)) {
+    universes[universeIndexAsString] = frameToUniverse(universeIndexAsString, frame);
+  }
+
+  return universes;
+};

--- a/src/core/fixtures/index.ts
+++ b/src/core/fixtures/index.ts
@@ -1,0 +1,5 @@
+export * from './types';
+export * from './cache';
+export * from './registry';
+export * from './patch-editor';
+export * from './engine-mapper';

--- a/src/core/fixtures/patch-editor.ts
+++ b/src/core/fixtures/patch-editor.ts
@@ -1,0 +1,177 @@
+import {
+  DMX_UNIVERSE_MAX_CHANNELS,
+  type PatchFixture,
+  type PatchValidationIssue,
+  type PatchedChannelMapping,
+  type PatchRenderMapping,
+} from './types';
+import type { FixtureProfileRegistry } from './registry';
+
+const clampChannelByte = (value: number): number => Math.max(0, Math.min(255, Math.round(value)));
+
+const getFixtureChannelCount = (fixture: PatchFixture, registry: FixtureProfileRegistry): number => {
+  const profile = registry.getProfile(fixture.profileId);
+  if (!profile) {
+    return 0;
+  }
+
+  const mode = profile.modes.find((candidate) => candidate.id === fixture.modeId);
+  if (!mode) {
+    return 0;
+  }
+
+  return mode.channels.length;
+};
+
+const getFixtureAddresses = (
+  fixture: PatchFixture,
+  registry: FixtureProfileRegistry,
+): ReadonlyArray<number> => {
+  const count = getFixtureChannelCount(fixture, registry);
+  const addresses: number[] = [];
+  for (let index = 0; index < count; index += 1) {
+    addresses.push(fixture.address + index);
+  }
+  return addresses;
+};
+
+export const validatePatchFixtures = (
+  fixtures: ReadonlyArray<PatchFixture>,
+  registry: FixtureProfileRegistry,
+): ReadonlyArray<PatchValidationIssue> => {
+  const issues: PatchValidationIssue[] = [];
+  const occupiedAddresses = new Map<string, string>();
+
+  for (const fixture of fixtures) {
+    const profile = registry.getProfile(fixture.profileId);
+    if (!profile) {
+      issues.push({
+        type: 'missingProfile',
+        fixtureId: fixture.id,
+        message: `Fixture "${fixture.name}" references unknown profile "${fixture.profileId}"`,
+      });
+      continue;
+    }
+
+    const mode = profile.modes.find((candidate) => candidate.id === fixture.modeId);
+    if (!mode) {
+      issues.push({
+        type: 'missingMode',
+        fixtureId: fixture.id,
+        message: `Fixture "${fixture.name}" references unknown mode "${fixture.modeId}"`,
+      });
+      continue;
+    }
+
+    const startAddress = fixture.address;
+    const endAddress = fixture.address + mode.channels.length - 1;
+    if (startAddress < 1 || endAddress > DMX_UNIVERSE_MAX_CHANNELS) {
+      issues.push({
+        type: 'universeOverflow',
+        fixtureId: fixture.id,
+        channels: [startAddress, endAddress],
+        message:
+          `Fixture "${fixture.name}" overflow in universe ${fixture.universe}: ` +
+          `channels ${startAddress}..${endAddress} outside 1..${DMX_UNIVERSE_MAX_CHANNELS}`,
+      });
+      continue;
+    }
+
+    const addresses = getFixtureAddresses(fixture, registry);
+    for (const address of addresses) {
+      const key = `${fixture.universe}:${address}`;
+      const existingFixtureId = occupiedAddresses.get(key);
+      if (existingFixtureId && existingFixtureId !== fixture.id) {
+        issues.push({
+          type: 'addressCollision',
+          fixtureId: fixture.id,
+          channels: [address],
+          message:
+            `Collision on universe ${fixture.universe} address ${address} ` +
+            `between fixtures "${existingFixtureId}" and "${fixture.id}"`,
+        });
+        continue;
+      }
+
+      occupiedAddresses.set(key, fixture.id);
+    }
+  }
+
+  return issues;
+};
+
+export class FixturePatchEditor {
+  private fixturesById = new Map<string, PatchFixture>();
+
+  constructor(private readonly registry: FixtureProfileRegistry) {}
+
+  listFixtures(): ReadonlyArray<PatchFixture> {
+    return [...this.fixturesById.values()];
+  }
+
+  upsertFixture(fixture: PatchFixture): void {
+    this.fixturesById.set(fixture.id, fixture);
+  }
+
+  removeFixture(fixtureId: string): void {
+    this.fixturesById.delete(fixtureId);
+  }
+
+  validate(): ReadonlyArray<PatchValidationIssue> {
+    return validatePatchFixtures(this.listFixtures(), this.registry);
+  }
+
+  buildRenderMapping(): PatchRenderMapping {
+    const issues = this.validate();
+    if (issues.length > 0) {
+      throw new Error(`Patch includes ${issues.length} blocking issue(s)`);
+    }
+
+    const channelMappings: PatchedChannelMapping[] = [];
+    const universeFrames = new Map<number, number[]>();
+
+    for (const fixture of this.listFixtures()) {
+      const profile = this.registry.getProfile(fixture.profileId);
+      if (!profile) {
+        continue;
+      }
+
+      const mode = profile.modes.find((candidate) => candidate.id === fixture.modeId);
+      if (!mode) {
+        continue;
+      }
+
+      if (!universeFrames.has(fixture.universe)) {
+        universeFrames.set(fixture.universe, Array.from({ length: DMX_UNIVERSE_MAX_CHANNELS }, () => 0));
+      }
+
+      const frame = universeFrames.get(fixture.universe);
+      if (!frame) {
+        continue;
+      }
+
+      mode.channels.forEach((channel, index) => {
+        const address = fixture.address + index;
+        const defaultValue = clampChannelByte(channel.defaultValue ?? 0);
+        frame[address - 1] = defaultValue;
+
+        channelMappings.push({
+          fixtureId: fixture.id,
+          fixtureName: fixture.name,
+          profileId: fixture.profileId,
+          modeId: fixture.modeId,
+          channelKey: channel.key,
+          channelName: channel.name,
+          universe: fixture.universe,
+          address,
+          defaultValue,
+        });
+      });
+    }
+
+    return {
+      channelMappings,
+      universeFrames: Object.fromEntries(universeFrames.entries()),
+    };
+  }
+}

--- a/src/core/fixtures/registry.ts
+++ b/src/core/fixtures/registry.ts
@@ -1,0 +1,106 @@
+import {
+  FIXTURE_PROFILE_FORMAT_VERSION,
+  type FixtureProfile,
+  type FixtureProfileCache,
+  type FixtureProfileMode,
+} from './types';
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const normalizeMode = (mode: unknown, profileId: string): FixtureProfileMode => {
+  if (!isRecord(mode) || typeof mode.id !== 'string' || typeof mode.name !== 'string') {
+    throw new Error(`Invalid mode for profile "${profileId}"`);
+  }
+
+  if (!Array.isArray(mode.channels) || mode.channels.length === 0) {
+    throw new Error(`Profile "${profileId}" mode "${mode.id}" must expose at least one channel`);
+  }
+
+  for (const channel of mode.channels) {
+    if (!isRecord(channel) || typeof channel.key !== 'string' || typeof channel.name !== 'string') {
+      throw new Error(`Profile "${profileId}" mode "${mode.id}" includes an invalid channel`);
+    }
+  }
+
+  return mode as FixtureProfileMode;
+};
+
+const normalizeProfile = (profile: unknown): FixtureProfile => {
+  if (!isRecord(profile)) {
+    throw new Error('Fixture profile payload must be an object');
+  }
+
+  if (profile.format !== FIXTURE_PROFILE_FORMAT_VERSION) {
+    throw new Error(`Unsupported fixture profile format: ${String(profile.format)}`);
+  }
+
+  if (
+    typeof profile.profileId !== 'string' ||
+    typeof profile.manufacturer !== 'string' ||
+    typeof profile.model !== 'string'
+  ) {
+    throw new Error('Fixture profile metadata is invalid');
+  }
+
+  if (!Array.isArray(profile.modes) || profile.modes.length === 0) {
+    throw new Error(`Fixture profile "${profile.profileId}" must provide modes`);
+  }
+
+  const normalizedModes = profile.modes.map((mode) => normalizeMode(mode, profile.profileId));
+  return {
+    ...profile,
+    modes: normalizedModes,
+  } as FixtureProfile;
+};
+
+export class FixtureProfileRegistry {
+  private readonly profilesById = new Map<string, FixtureProfile>();
+
+  constructor(private readonly cache?: FixtureProfileCache) {}
+
+  async loadFromCache(): Promise<void> {
+    if (!this.cache) {
+      return;
+    }
+
+    const cachedProfiles = await this.cache.loadAll();
+    for (const cachedProfile of cachedProfiles) {
+      const normalizedProfile = normalizeProfile(cachedProfile);
+      this.profilesById.set(normalizedProfile.profileId, normalizedProfile);
+    }
+  }
+
+  listProfiles(): ReadonlyArray<FixtureProfile> {
+    return [...this.profilesById.values()];
+  }
+
+  getProfile(profileId: string): FixtureProfile | undefined {
+    return this.profilesById.get(profileId);
+  }
+
+  importProfiles(profiles: ReadonlyArray<FixtureProfile>): void {
+    for (const profile of profiles) {
+      const normalizedProfile = normalizeProfile(profile);
+      this.profilesById.set(normalizedProfile.profileId, normalizedProfile);
+    }
+  }
+
+  importProfilesFromJson(payload: string): void {
+    const parsedPayload = JSON.parse(payload) as unknown;
+    if (!Array.isArray(parsedPayload)) {
+      throw new Error('Fixture profile import payload must be an array');
+    }
+
+    const profiles = parsedPayload.map((item) => normalizeProfile(item));
+    this.importProfiles(profiles);
+  }
+
+  async persist(): Promise<void> {
+    if (!this.cache) {
+      return;
+    }
+
+    await this.cache.saveAll(this.listProfiles());
+  }
+}

--- a/src/core/fixtures/types.ts
+++ b/src/core/fixtures/types.ts
@@ -1,0 +1,75 @@
+export const DMX_UNIVERSE_MAX_CHANNELS = 512;
+export const FIXTURE_PROFILE_FORMAT_VERSION = 'lightai.fixture.v1';
+
+export type FixtureChannelValue = number;
+
+export type FixtureChannelType =
+  | 'intensity'
+  | 'color'
+  | 'position'
+  | 'effect'
+  | 'strobe'
+  | 'control'
+  | 'custom';
+
+export interface FixtureChannelDefinition {
+  key: string;
+  name: string;
+  type: FixtureChannelType;
+  defaultValue?: FixtureChannelValue;
+}
+
+export interface FixtureProfileMode {
+  id: string;
+  name: string;
+  channels: ReadonlyArray<FixtureChannelDefinition>;
+}
+
+export interface FixtureProfile {
+  /**
+   * Internal format inspired by Open Fixture Library mode/channel model.
+   */
+  format: typeof FIXTURE_PROFILE_FORMAT_VERSION;
+  manufacturer: string;
+  model: string;
+  profileId: string;
+  modes: ReadonlyArray<FixtureProfileMode>;
+}
+
+export interface PatchFixture {
+  id: string;
+  name: string;
+  profileId: string;
+  modeId: string;
+  universe: number;
+  address: number;
+}
+
+export interface PatchValidationIssue {
+  type: 'missingProfile' | 'missingMode' | 'addressCollision' | 'universeOverflow';
+  fixtureId: string;
+  message: string;
+  channels?: number[];
+}
+
+export interface PatchedChannelMapping {
+  fixtureId: string;
+  fixtureName: string;
+  profileId: string;
+  modeId: string;
+  channelKey: string;
+  channelName: string;
+  universe: number;
+  address: number;
+  defaultValue: number;
+}
+
+export interface PatchRenderMapping {
+  channelMappings: ReadonlyArray<PatchedChannelMapping>;
+  universeFrames: Readonly<Record<number, ReadonlyArray<number>>>;
+}
+
+export interface FixtureProfileCache {
+  loadAll(): Promise<ReadonlyArray<FixtureProfile>>;
+  saveAll(profiles: ReadonlyArray<FixtureProfile>): Promise<void>;
+}

--- a/src/core/lighting-engine/index.ts
+++ b/src/core/lighting-engine/index.ts
@@ -5,3 +5,5 @@ export * from './scheduler';
 export * from './serialization';
 
 export * from '../protocols';
+
+export * from '../fixtures';


### PR DESCRIPTION
### Motivation
- Introduce a local fixture profile model and patching pipeline to support DMX fixture import, patch editing and mapping to rendering frames. 
- Provide a validated, cacheable registry of fixture profiles to enable importing manufacturer modes and channel definitions. 
- Prevent runtime errors by validating address collisions and universe overflow when building a fixture patch. 

### Description
- Add a new `src/core/fixtures` module with types describing an internal fixture profile format (`lightai.fixture.v1`), patch fixtures, validation issues, and render mappings (`types.ts`).
- Implement `FixtureProfileRegistry` with JSON import, structural validation/normalization, lookup by `profileId`, optional cache persistence, and an in-memory cache `InMemoryFixtureProfileCache` (`registry.ts`, `cache.ts`).
- Implement `FixturePatchEditor` to upsert/remove fixtures, validate patches for missing profiles/modes, address collisions and universe overflow (1..512), and to produce a `PatchRenderMapping` with per-universe frames and channel mappings (`patch-editor.ts`).
- Add `engine-mapper.ts` to convert `PatchRenderMapping` into `ShowState['universes']` for the lighting engine, re-export the fixtures module from the lighting engine public index, and include a README documenting the profile format and workflow. (`engine-mapper.ts`, `index.ts`, `README.md`, `lighting-engine/index.ts`).

### Testing
- Ran `npx eslint src/core/fixtures/*.ts src/core/lighting-engine/index.ts` which passed for the new/modified fixture files. 
- Ran `npm run lint` which failed due to pre-existing lint violations in unrelated files (errors/warnings in `src/components/*` and `src/lib/*`).
- Ran `npx tsc -p tsconfig.app.json --noEmit` which failed due to pre-existing TypeScript errors outside the new fixtures module (unrelated files such as `src/components/*`, `src/lib/*`, and an existing serialization assertion).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d31d88d6c0832aa25e17f8fffe8b1e)