### PR TITLE
Add deterministic show timeline core module

### DIFF
--- a/src/core/show/controller.ts
+++ b/src/core/show/controller.ts
@@ -1,0 +1,106 @@
+import { createInitialShowRunState, evaluateTimeline } from './executor';
+import type { ShowRunState, ShowTimeline, TimelineSnapshot } from './types';
+
+export class ShowController {
+  private state: ShowRunState = createInitialShowRunState();
+
+  constructor(private readonly timeline: ShowTimeline) {}
+
+  getState(): ShowRunState {
+    return this.state;
+  }
+
+  go(nowMs: number): TimelineSnapshot {
+    const cueId = this.state.cursor.cueId ?? this.timeline.entryCueId;
+    const elapsedMs = this.state.pausedAtMs !== null ? this.state.cursor.elapsedMs : 0;
+
+    this.state = {
+      ...this.state,
+      cursor: {
+        ...this.state.cursor,
+        cueId,
+        elapsedMs,
+      },
+      playing: true,
+      pausedAtMs: null,
+      anchorStartedAtMs: nowMs - elapsedMs,
+      blackout: false,
+      historyCueIds:
+        cueId && this.state.historyCueIds[this.state.historyCueIds.length - 1] !== cueId
+          ? [...this.state.historyCueIds, cueId]
+          : this.state.historyCueIds,
+    };
+
+    return this.tick(nowMs);
+  }
+
+  pause(nowMs: number): TimelineSnapshot {
+    const evaluated = evaluateTimeline(this.timeline, this.state, nowMs);
+    this.state = {
+      ...evaluated.state,
+      playing: false,
+      pausedAtMs: nowMs,
+      anchorStartedAtMs: null,
+    };
+
+    return evaluated.snapshot;
+  }
+
+  back(nowMs: number): TimelineSnapshot {
+    const history = this.state.historyCueIds;
+    const previous = history.length > 1 ? history[history.length - 2] : this.timeline.entryCueId;
+
+    this.state = {
+      ...this.state,
+      cursor: {
+        cueId: previous ?? null,
+        chaseId: null,
+        chaseIndex: -1,
+        elapsedMs: 0,
+      },
+      historyCueIds: previous ? [...history.slice(0, -1)] : [],
+      blackout: false,
+      anchorStartedAtMs: this.state.playing ? nowMs : null,
+      pausedAtMs: this.state.playing ? null : nowMs,
+    };
+
+    return this.tick(nowMs);
+  }
+
+  jumpCue(cueId: string, nowMs: number): TimelineSnapshot {
+    if (!this.timeline.cues[cueId]) {
+      throw new Error(`Cue "${cueId}" does not exist in the timeline`);
+    }
+
+    this.state = {
+      ...this.state,
+      cursor: {
+        cueId,
+        chaseId: null,
+        chaseIndex: -1,
+        elapsedMs: 0,
+      },
+      blackout: false,
+      historyCueIds: [...this.state.historyCueIds, cueId],
+      anchorStartedAtMs: this.state.playing ? nowMs : null,
+      pausedAtMs: this.state.playing ? null : nowMs,
+    };
+
+    return this.tick(nowMs);
+  }
+
+  blackout(nowMs: number): TimelineSnapshot {
+    this.state = {
+      ...this.state,
+      blackout: true,
+    };
+
+    return this.tick(nowMs);
+  }
+
+  tick(nowMs: number): TimelineSnapshot {
+    const evaluated = evaluateTimeline(this.timeline, this.state, nowMs);
+    this.state = evaluated.state;
+    return evaluated.snapshot;
+  }
+}

--- a/src/core/show/executor.ts
+++ b/src/core/show/executor.ts
@@ -1,0 +1,297 @@
+import type {
+  Chase,
+  Cue,
+  Scene,
+  ShowRunState,
+  ShowTimeline,
+  TimelineSnapshot,
+} from './types';
+
+const clamp = (value: number): number => Math.max(0, Math.min(255, Math.round(value)));
+
+const toSceneMap = (scene?: Scene): Map<string, number> => {
+  const map = new Map<string, number>();
+  if (!scene) {
+    return map;
+  }
+
+  for (const value of scene.values) {
+    map.set(`${value.universeId}:${value.channel}`, clamp(value.value));
+  }
+
+  return map;
+};
+
+const mergeKeys = (a: Map<string, number>, b: Map<string, number>): string[] => {
+  const keys = new Set<string>();
+  for (const key of a.keys()) keys.add(key);
+  for (const key of b.keys()) keys.add(key);
+  return Array.from(keys.values());
+};
+
+const blendScenes = (
+  from: Map<string, number>,
+  to: Map<string, number>,
+  ratio: number,
+): Record<string, number> => {
+  const r = Math.max(0, Math.min(1, ratio));
+  const values: Record<string, number> = {};
+  for (const key of mergeKeys(from, to)) {
+    const fromValue = from.get(key) ?? 0;
+    const toValue = to.get(key) ?? 0;
+    values[key] = clamp(fromValue + (toValue - fromValue) * r);
+  }
+  return values;
+};
+
+const blackoutFrame = (values: Record<string, number>): Record<string, number> => {
+  const out: Record<string, number> = {};
+  for (const key of Object.keys(values)) {
+    out[key] = 0;
+  }
+  return out;
+};
+
+const cueDuration = (cue: Cue): number =>
+  Math.max(0, cue.transition.fadeInMs) +
+  Math.max(0, cue.transition.holdMs) +
+  Math.max(0, cue.transition.fadeOutMs);
+
+const previousCueId = (history: string[]): string | null => {
+  if (history.length < 2) {
+    return null;
+  }
+  return history[history.length - 2] ?? null;
+};
+
+const resolveNextFromChase = (
+  chase: Chase,
+  currentCueId: string,
+): { cueId: string | null; chaseIndex: number } | null => {
+  const index = chase.cueIds.indexOf(currentCueId);
+  if (index < 0) {
+    return null;
+  }
+
+  const nextIndex = index + 1;
+  if (nextIndex < chase.cueIds.length) {
+    return {
+      cueId: chase.cueIds[nextIndex],
+      chaseIndex: nextIndex,
+    };
+  }
+
+  if (!chase.loop || chase.cueIds.length === 0) {
+    return { cueId: null, chaseIndex: -1 };
+  }
+
+  return {
+    cueId: chase.cueIds[0],
+    chaseIndex: 0,
+  };
+};
+
+const resolveFollow = (
+  timeline: ShowTimeline,
+  state: ShowRunState,
+): { cueId: string | null; chaseId: string | null; chaseIndex: number } => {
+  const cueId = state.cursor.cueId;
+  if (!cueId) {
+    return { cueId: null, chaseId: null, chaseIndex: -1 };
+  }
+
+  const cue = timeline.cues[cueId];
+  if (!cue) {
+    return { cueId: null, chaseId: null, chaseIndex: -1 };
+  }
+
+  if (state.cursor.chaseId) {
+    const chase = timeline.chases[state.cursor.chaseId];
+    if (chase) {
+      const nextInChase = resolveNextFromChase(chase, cueId);
+      if (nextInChase) {
+        return {
+          cueId: nextInChase.cueId,
+          chaseId: nextInChase.cueId ? chase.id : null,
+          chaseIndex: nextInChase.chaseIndex,
+        };
+      }
+    }
+  }
+
+  switch (cue.transition.follow) {
+    case 'hold':
+      return { cueId, chaseId: state.cursor.chaseId, chaseIndex: state.cursor.chaseIndex };
+    case 'stop':
+    case 'blackout':
+      return { cueId: null, chaseId: null, chaseIndex: -1 };
+    case 'cue':
+      return {
+        cueId: cue.transition.followCueId ?? null,
+        chaseId: null,
+        chaseIndex: -1,
+      };
+    case 'chase': {
+      const chase = cue.transition.followChaseId
+        ? timeline.chases[cue.transition.followChaseId]
+        : undefined;
+      if (!chase || chase.cueIds.length === 0) {
+        return { cueId: null, chaseId: null, chaseIndex: -1 };
+      }
+      return {
+        cueId: chase.cueIds[0],
+        chaseId: chase.id,
+        chaseIndex: 0,
+      };
+    }
+    case 'next': {
+      const cueIds = Object.keys(timeline.cues);
+      const currentIndex = cueIds.indexOf(cueId);
+      if (currentIndex < 0 || currentIndex + 1 >= cueIds.length) {
+        return { cueId: null, chaseId: null, chaseIndex: -1 };
+      }
+      return {
+        cueId: cueIds[currentIndex + 1],
+        chaseId: null,
+        chaseIndex: -1,
+      };
+    }
+    default:
+      return { cueId: null, chaseId: null, chaseIndex: -1 };
+  }
+};
+
+const ensureCursorCue = (timeline: ShowTimeline, state: ShowRunState): ShowRunState => {
+  if (state.cursor.cueId || !timeline.entryCueId) {
+    return state;
+  }
+
+  return {
+    ...state,
+    cursor: {
+      ...state.cursor,
+      cueId: timeline.entryCueId,
+      elapsedMs: 0,
+    },
+    historyCueIds: [...state.historyCueIds, timeline.entryCueId],
+  };
+};
+
+export const createInitialShowRunState = (): ShowRunState => ({
+  cursor: {
+    cueId: null,
+    chaseId: null,
+    chaseIndex: -1,
+    elapsedMs: 0,
+  },
+  playing: false,
+  pausedAtMs: null,
+  anchorStartedAtMs: null,
+  historyCueIds: [],
+  blackout: false,
+});
+
+export const evaluateTimeline = (
+  timeline: ShowTimeline,
+  state: ShowRunState,
+  nowMs: number,
+): { state: ShowRunState; snapshot: TimelineSnapshot } => {
+  let nextState = ensureCursorCue(timeline, state);
+
+  if (nextState.playing && nextState.anchorStartedAtMs !== null) {
+    const elapsedSinceStart = Math.max(0, nowMs - nextState.anchorStartedAtMs);
+    nextState = {
+      ...nextState,
+      cursor: {
+        ...nextState.cursor,
+        elapsedMs: elapsedSinceStart,
+      },
+    };
+
+    let guard = 0;
+    while (nextState.cursor.cueId && guard < 256) {
+      guard += 1;
+      const cue = timeline.cues[nextState.cursor.cueId];
+      if (!cue) {
+        nextState = {
+          ...nextState,
+          cursor: { ...nextState.cursor, cueId: null, chaseId: null, chaseIndex: -1, elapsedMs: 0 },
+          playing: false,
+          anchorStartedAtMs: null,
+          pausedAtMs: nowMs,
+        };
+        break;
+      }
+
+      const duration = cueDuration(cue);
+      if (nextState.cursor.elapsedMs < duration || duration === 0) {
+        break;
+      }
+
+      const remainder = nextState.cursor.elapsedMs - duration;
+      const resolved = resolveFollow(timeline, nextState);
+      const shouldBlackout = cue.transition.follow === 'blackout';
+      if (!resolved.cueId) {
+        nextState = {
+          ...nextState,
+          cursor: { cueId: null, chaseId: null, chaseIndex: -1, elapsedMs: 0 },
+          playing: false,
+          anchorStartedAtMs: null,
+          pausedAtMs: nowMs,
+          blackout: shouldBlackout ? true : nextState.blackout,
+        };
+        break;
+      }
+
+      nextState = {
+        ...nextState,
+        cursor: {
+          cueId: resolved.cueId,
+          chaseId: resolved.chaseId,
+          chaseIndex: resolved.chaseIndex,
+          elapsedMs: remainder,
+        },
+        historyCueIds: [...nextState.historyCueIds, resolved.cueId],
+        anchorStartedAtMs: nowMs - remainder,
+      };
+    }
+  }
+
+  const cue = nextState.cursor.cueId ? timeline.cues[nextState.cursor.cueId] : undefined;
+  const currentScene = cue ? timeline.scenes[cue.sceneId] : undefined;
+  const fromCueId = previousCueId(nextState.historyCueIds);
+  const fromCue = fromCueId ? timeline.cues[fromCueId] : undefined;
+  const fromScene = fromCue ? timeline.scenes[fromCue.sceneId] : undefined;
+
+  const currentSceneMap = toSceneMap(currentScene);
+  const fromSceneMap = toSceneMap(fromScene);
+
+  let outputValues: Record<string, number> = {};
+
+  if (cue) {
+    const { fadeInMs, holdMs, fadeOutMs } = cue.transition;
+    const elapsed = Math.max(0, nextState.cursor.elapsedMs);
+    if (fadeInMs > 0 && elapsed < fadeInMs) {
+      outputValues = blendScenes(fromSceneMap, currentSceneMap, elapsed / fadeInMs);
+    } else if (elapsed < fadeInMs + holdMs || fadeOutMs <= 0) {
+      outputValues = blendScenes(currentSceneMap, currentSceneMap, 1);
+    } else {
+      const fadeOutElapsed = Math.min(fadeOutMs, elapsed - (fadeInMs + holdMs));
+      outputValues = blendScenes(currentSceneMap, new Map<string, number>(), fadeOutElapsed / fadeOutMs);
+    }
+  }
+
+  if (nextState.blackout) {
+    outputValues = blackoutFrame(outputValues);
+  }
+
+  return {
+    state: nextState,
+    snapshot: {
+      activeCueId: nextState.cursor.cueId,
+      values: outputValues,
+      playing: nextState.playing,
+      blackout: nextState.blackout,
+    },
+  };
+};

--- a/src/core/show/index.ts
+++ b/src/core/show/index.ts
@@ -1,0 +1,5 @@
+export * from './types';
+export * from './executor';
+export * from './controller';
+export * from './persistence';
+export * from './protocol-link';

--- a/src/core/show/persistence.ts
+++ b/src/core/show/persistence.ts
@@ -1,0 +1,51 @@
+import { defaultShowOutputConfig } from '../protocols/types';
+import type { ShowTimeline, UserProject } from './types';
+
+interface PersistedTimelinePayload {
+  version: 1;
+  timeline: ShowTimeline;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+export const createEmptyTimeline = (): ShowTimeline => ({
+  version: 1,
+  scenes: {},
+  cues: {},
+  chases: {},
+  entryCueId: null,
+  output: defaultShowOutputConfig,
+});
+
+export const serializeTimeline = (timeline: ShowTimeline): string =>
+  JSON.stringify({
+    version: 1,
+    timeline,
+  } satisfies PersistedTimelinePayload);
+
+export const deserializeTimeline = (json: string): ShowTimeline => {
+  const parsed = JSON.parse(json) as unknown;
+  if (!isRecord(parsed) || parsed.version !== 1 || !('timeline' in parsed)) {
+    throw new Error('Invalid show timeline payload');
+  }
+
+  const timeline = parsed.timeline as ShowTimeline;
+
+  return {
+    ...timeline,
+    output: timeline.output ?? defaultShowOutputConfig,
+    version: 1,
+  };
+};
+
+export const attachTimelineToProject = (
+  project: UserProject,
+  timeline: ShowTimeline,
+): UserProject => ({
+  ...project,
+  showTimeline: timeline,
+});
+
+export const readTimelineFromProject = (project: UserProject): ShowTimeline =>
+  project.showTimeline ?? createEmptyTimeline();

--- a/src/core/show/protocol-link.ts
+++ b/src/core/show/protocol-link.ts
@@ -1,0 +1,57 @@
+import { LightingOutputRouter } from '../protocols/selector';
+import type { ShowOutputConfig } from '../protocols/types';
+import type { ShowState, Universe } from '../lighting-engine/types';
+import type { TimelineSnapshot } from './types';
+
+const parseUniverseKey = (key: string): { universeId: string; channel: number } => {
+  const [universeId, channelAsString] = key.split(':');
+  return {
+    universeId,
+    channel: Number(channelAsString),
+  };
+};
+
+const snapshotToUniverses = (snapshot: TimelineSnapshot): Record<string, Universe> => {
+  const universes: Record<string, Universe> = {};
+
+  for (const [key, value] of Object.entries(snapshot.values)) {
+    const { universeId, channel } = parseUniverseKey(key);
+    const universe = universes[universeId] ?? {
+      id: universeId,
+      name: universeId,
+      size: 512,
+      channels: {},
+    };
+
+    universe.channels[channel] = Math.max(0, Math.min(255, Math.round(value)));
+    universes[universeId] = universe;
+  }
+
+  return universes;
+};
+
+const snapshotToShowState = (
+  snapshot: TimelineSnapshot,
+  output: ShowOutputConfig,
+): ShowState => ({
+  fixtures: {},
+  scenes: {},
+  cues: {},
+  activeCue: null,
+  currentSceneId: snapshot.activeCueId,
+  tick: 0,
+  output,
+  universes: snapshotToUniverses(snapshot),
+});
+
+export class ShowProtocolLink {
+  constructor(private readonly router: LightingOutputRouter) {}
+
+  async configure(output: ShowOutputConfig): Promise<void> {
+    await this.router.setConfiguration(output);
+  }
+
+  async sendSnapshot(snapshot: TimelineSnapshot, output: ShowOutputConfig): Promise<void> {
+    await this.router.applyState(snapshotToShowState(snapshot, output));
+  }
+}

--- a/src/core/show/types.ts
+++ b/src/core/show/types.ts
@@ -1,0 +1,79 @@
+import type { ShowOutputConfig } from '../protocols/types';
+
+export type ChannelLevel = number;
+
+export interface SceneValue {
+  universeId: string;
+  channel: number;
+  value: ChannelLevel;
+}
+
+export interface Scene {
+  id: string;
+  name: string;
+  values: SceneValue[];
+}
+
+export type CueFollowMode = 'next' | 'hold' | 'stop' | 'cue' | 'chase' | 'blackout';
+
+export interface Transition {
+  fadeInMs: number;
+  holdMs: number;
+  fadeOutMs: number;
+  follow: CueFollowMode;
+  followCueId?: string;
+  followChaseId?: string;
+}
+
+export interface Cue {
+  id: string;
+  name: string;
+  sceneId: string;
+  transition: Transition;
+}
+
+export interface Chase {
+  id: string;
+  name: string;
+  cueIds: string[];
+  loop: boolean;
+}
+
+export interface ShowTimeline {
+  version: 1;
+  scenes: Record<string, Scene>;
+  cues: Record<string, Cue>;
+  chases: Record<string, Chase>;
+  entryCueId: string | null;
+  output: ShowOutputConfig;
+}
+
+export interface TimelineCursor {
+  cueId: string | null;
+  chaseId: string | null;
+  chaseIndex: number;
+  elapsedMs: number;
+}
+
+export interface ShowRunState {
+  cursor: TimelineCursor;
+  playing: boolean;
+  pausedAtMs: number | null;
+  anchorStartedAtMs: number | null;
+  historyCueIds: string[];
+  blackout: boolean;
+}
+
+export interface TimelineSnapshot {
+  activeCueId: string | null;
+  values: Record<string, ChannelLevel>;
+  playing: boolean;
+  blackout: boolean;
+}
+
+export interface UserProject {
+  id: string;
+  name?: string;
+  showTimeline?: ShowTimeline;
+  [key: string]: unknown;
+}


### PR DESCRIPTION
### Motivation
- Provide a foundational, deterministic timeline engine for shows with first-class domain models for scenes, cues, chases and transitions.
- Enable live transport controls (go/pause/back/jump/blackout) and produce time-consistent snapshots that can be routed to existing protocol outputs.
- Persist timelines inside user projects so timelines can be saved/loaded with the project.

### Description
- Add new module `src/core/show/` exporting types and functionality including `Scene`, `Cue`, `Chase`, `Transition`, `ShowTimeline`, and runtime state types (`types.ts`).
- Implement deterministic timeline evaluation in `executor.ts` with fade-in/hold/fade-out interpolation, follow resolution (next/hold/stop/cue/chase/blackout), chase handling, and snapshot generation of channel values.
- Add `ShowController` (`controller.ts`) exposing live controls: `go`, `pause`, `back`, `jumpCue`, `blackout`, and `tick` to drive the timeline run-state.
- Add persistence helpers in `persistence.ts` for versioned serialization/deserialization and attaching/reading a timeline on `UserProject`, and add `ShowProtocolLink` (`protocol-link.ts`) to convert snapshots into `ShowState` and route them through the existing `LightingOutputRouter`.

### Testing
- Ran `npm run build` which completed successfully and validated TypeScript compilation and bundle generation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d320b59ebc832ab9d6ba1e8d00b01e)