### PR TITLE
feat: add structured observability, diagnostics panel and incident export

### DIFF
--- a/desktop/ipc/contracts.ts
+++ b/desktop/ipc/contracts.ts
@@ -20,10 +20,17 @@ export type HardwareDevice = {
   online: boolean;
 };
 
+export type RuntimeMetrics = {
+  protocolQueueDepth: number;
+  protocolQueueHighWatermark: number;
+  protocolDroppedFrames: number;
+};
+
 export type RuntimeStatus = {
   ready: boolean;
   connectedDeviceId: string | null;
   protocol: DeviceProtocol | null;
+  metrics: RuntimeMetrics;
 };
 
 export type ConnectDeviceRequest = {

--- a/desktop/native/hardwareRuntime.ts
+++ b/desktop/native/hardwareRuntime.ts
@@ -6,11 +6,22 @@ const mockDevices: HardwareDevice[] = [
   { id: 'osc-bridge-01', name: 'OSC Bridge', protocol: 'osc', online: true }
 ];
 
+const MAX_PROTOCOL_QUEUE_DEPTH = 120;
+
 export class HardwareRuntime {
+  private protocolQueueDepth = 0;
+  private protocolQueueHighWatermark = 0;
+  private protocolDroppedFrames = 0;
+
   private status: RuntimeStatus = {
     ready: true,
     connectedDeviceId: null,
-    protocol: null
+    protocol: null,
+    metrics: {
+      protocolQueueDepth: 0,
+      protocolQueueHighWatermark: 0,
+      protocolDroppedFrames: 0
+    }
   };
 
   listDevices(): HardwareDevice[] {
@@ -26,7 +37,8 @@ export class HardwareRuntime {
     this.status = {
       ready: true,
       connectedDeviceId: device.id,
-      protocol: device.protocol
+      protocol: device.protocol,
+      metrics: this.readMetrics()
     };
 
     return this.status;
@@ -36,7 +48,8 @@ export class HardwareRuntime {
     this.status = {
       ...this.status,
       connectedDeviceId: null,
-      protocol: null
+      protocol: null,
+      metrics: this.readMetrics()
     };
     return this.status;
   }
@@ -48,9 +61,45 @@ export class HardwareRuntime {
 
     // NOTE: Protocol adapters (DMX/Art-Net/OSC) must remain in this native layer.
     void request;
+
+    if (this.protocolQueueDepth >= MAX_PROTOCOL_QUEUE_DEPTH) {
+      this.protocolDroppedFrames += 1;
+      this.status = {
+        ...this.status,
+        metrics: this.readMetrics()
+      };
+      return;
+    }
+
+    this.protocolQueueDepth += 1;
+    this.protocolQueueHighWatermark = Math.max(this.protocolQueueHighWatermark, this.protocolQueueDepth);
+
+    setTimeout(() => {
+      this.protocolQueueDepth = Math.max(0, this.protocolQueueDepth - 1);
+      this.status = {
+        ...this.status,
+        metrics: this.readMetrics()
+      };
+    }, 8);
+
+    this.status = {
+      ...this.status,
+      metrics: this.readMetrics()
+    };
   }
 
   getStatus(): RuntimeStatus {
-    return this.status;
+    return {
+      ...this.status,
+      metrics: this.readMetrics()
+    };
+  }
+
+  private readMetrics() {
+    return {
+      protocolQueueDepth: this.protocolQueueDepth,
+      protocolQueueHighWatermark: this.protocolQueueHighWatermark,
+      protocolDroppedFrames: this.protocolDroppedFrames
+    };
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,8 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import toast, { Toaster } from 'react-hot-toast';
 import { AuthModal } from './components/AuthModal';
 import { EffectSidePanel } from './components/layout/EffectSidePanel';
+import { DiagnosticsPanel } from './components/layout/DiagnosticsPanel';
 import { HeroSection } from './components/layout/HeroSection';
 import { MarketingSections } from './components/layout/MarketingSections';
 import { Navbar } from './components/layout/Navbar';
@@ -16,12 +17,55 @@ import {
   rollbackConfiguration
 } from './lib/effectConfiguration';
 import { effects } from './lib/effects';
+import { buildIncidentReport, downloadIncidentReport, observability } from './lib/observability';
+import { runtimeClient } from './lib/runtimeClient';
 import { supabase } from './lib/supabase';
 
 function App() {
   const [showVirtualStage, setShowVirtualStage] = useState(false);
   const [showEffectPanel, setShowEffectPanel] = useState(false);
+  const [showDiagnostics, setShowDiagnostics] = useState(false);
+  const [runtimeStatus, setRuntimeStatus] = useState(() => ({
+    ready: false,
+    connectedDeviceId: null,
+    protocol: null,
+    metrics: {
+      protocolQueueDepth: 0,
+      protocolQueueHighWatermark: 0,
+      protocolDroppedFrames: 0
+    }
+  }));
   const profileState = useSupabaseProfile();
+
+
+  useEffect(() => {
+    observability.setShowId('main-show');
+    observability.info('app', 'Application booted');
+  }, []);
+
+  useEffect(() => {
+    const pollStatus = () => {
+      runtimeClient
+        .getRuntimeStatus()
+        .then((status) => {
+          setRuntimeStatus(status);
+          observability.setProtocolMetrics({
+            queueDepth: status.metrics.protocolQueueDepth,
+            queueHighWatermark: status.metrics.protocolQueueHighWatermark,
+            droppedFrames: status.metrics.protocolDroppedFrames
+          });
+        })
+        .catch((error) => {
+          observability.warn('runtime', 'Runtime status polling failed', {
+            reason: error instanceof Error ? error.message : String(error)
+          });
+        });
+    };
+
+    pollStatus();
+    const id = window.setInterval(pollStatus, 1000);
+    return () => clearInterval(id);
+  }, []);
 
   const traceAuditEvent = useCallback(
     async (
@@ -39,7 +83,7 @@ function App() {
         ...payload
       };
 
-      console.info('[PresetAudit]', technicalAudit);
+      observability.info('preset-audit', action, technicalAudit);
 
       if (!profileState.profile) {
         return;
@@ -54,7 +98,9 @@ function App() {
       ]);
 
       if (error) {
-        console.error('Error tracing audit event:', error);
+        observability.error('preset-audit', 'Error tracing audit event', {
+          reason: error instanceof Error ? error.message : String(error)
+        });
       }
     },
     [profileState.profile]
@@ -73,7 +119,9 @@ function App() {
       ]);
 
       if (error) {
-        console.error('Error logging effect usage:', error);
+        observability.error('preset-audit', 'Error logging effect usage', {
+          reason: error instanceof Error ? error.message : String(error)
+        });
       }
     },
     [profileState.profile]
@@ -144,6 +192,35 @@ function App() {
     void applyPersistedConfiguration(configuration, 'history');
   }, [applyPersistedConfiguration]);
 
+
+  const exportIncidentReport = useCallback(
+    (scope: 'private' | 'public') => {
+      const report = buildIncidentReport({
+        exportScope: scope,
+        runtimeStatus,
+        appConfig: {
+          virtualStageEnabled: showVirtualStage,
+          effectPanelOpen: showEffectPanel,
+          activeEffectIndex: playbackState.currentEffect,
+          volume: playbackState.volume,
+          muted: playbackState.isMuted,
+          profile: profileState.profile
+            ? {
+                user_id: profileState.profile.id,
+                email: profileState.profile.email,
+                role: profileState.profile.role
+              }
+            : null
+        }
+      });
+
+      const suffix = scope === 'public' ? 'public' : 'private';
+      downloadIncidentReport(`lightai-incident-${suffix}-${new Date().toISOString()}.json`, report);
+      observability.info('diagnostics', 'Incident report exported', { scope });
+    },
+    [playbackState.currentEffect, playbackState.isMuted, playbackState.volume, profileState.profile, runtimeStatus, showEffectPanel, showVirtualStage]
+  );
+
   const appState = useMemo(
     () => ({
       profile: profileState.profile,
@@ -161,9 +238,16 @@ function App() {
         nextPreset: () => {
           // managed in dedicated virtual-stage hook
         }
+      },
+      diagnostics: {
+        isOpen: showDiagnostics,
+        toggle: () => setShowDiagnostics((prev) => !prev),
+        snapshot: observability.snapshot(),
+        runtimeStatus,
+        exportIncidentReport
       }
     }),
-    [playbackState, profileState, showEffectPanel, showVirtualStage]
+    [exportIncidentReport, playbackState, profileState, runtimeStatus, showDiagnostics, showEffectPanel, showVirtualStage]
   );
 
   return (
@@ -192,6 +276,7 @@ function App() {
           </div>
 
           <Navbar />
+          <DiagnosticsPanel />
           <HeroSection />
           <PlayerBar />
         </header>

--- a/src/components/layout/DiagnosticsPanel.tsx
+++ b/src/components/layout/DiagnosticsPanel.tsx
@@ -1,0 +1,79 @@
+import { AlertTriangle, Download, Shield } from 'lucide-react';
+import { useAppState } from '../../context/AppStateContext';
+
+export function DiagnosticsPanel() {
+  const { diagnostics } = useAppState();
+
+  if (!diagnostics.isOpen) {
+    return null;
+  }
+
+  const { snapshot, runtimeStatus } = diagnostics;
+
+  return (
+    <aside className="fixed left-6 top-24 bottom-6 w-[28rem] bg-black/90 border border-yellow-400/40 rounded-xl p-5 overflow-auto z-50">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-semibold text-yellow-300">Diagnostics</h2>
+        <button onClick={diagnostics.toggle} className="text-sm text-gray-300 hover:text-white">Fermer</button>
+      </div>
+
+      <div className="space-y-3 text-sm">
+        <div className="bg-gray-900/80 rounded-lg p-3">
+          <div>Session: <span className="text-yellow-300">{snapshot.sessionId}</span></div>
+          <div>Show: <span className="text-yellow-300">{snapshot.showId}</span></div>
+          <div>MAJ: <span className="text-gray-300">{new Date(snapshot.updatedAt).toLocaleString()}</span></div>
+        </div>
+
+        <div className="bg-gray-900/80 rounded-lg p-3 space-y-1">
+          <div className="font-medium">Runtime</div>
+          <div>Ready: {runtimeStatus.ready ? 'yes' : 'no'}</div>
+          <div>Protocol: {runtimeStatus.protocol ?? 'none'}</div>
+          <div>Queue: {runtimeStatus.metrics.protocolQueueDepth}</div>
+          <div>Queue max: {runtimeStatus.metrics.protocolQueueHighWatermark}</div>
+          <div>Dropped protocol frames: {runtimeStatus.metrics.protocolDroppedFrames}</div>
+        </div>
+
+        <div className="bg-gray-900/80 rounded-lg p-3 space-y-1">
+          <div className="font-medium">Frame Metrics</div>
+          <div>Latency avg: {snapshot.metrics.frameLatencyMsAvg} ms</div>
+          <div>Latency p95: {snapshot.metrics.frameLatencyMsP95} ms</div>
+          <div>Dropped frames: {snapshot.metrics.droppedFrames}</div>
+          <div>Total frames: {snapshot.metrics.totalFrames}</div>
+        </div>
+
+        <div className="bg-gray-900/80 rounded-lg p-3">
+          <div className="font-medium mb-2">Derniers logs</div>
+          <div className="space-y-2 max-h-56 overflow-auto pr-1">
+            {snapshot.logs.slice(0, 20).map((log) => (
+              <div key={log.id} className="border border-gray-700 rounded-md p-2">
+                <div className="text-xs text-gray-400">{new Date(log.timestamp).toLocaleTimeString()} • {log.level} • {log.module}</div>
+                <div>{log.message}</div>
+              </div>
+            ))}
+            {snapshot.logs.length === 0 && <div className="text-gray-400">Aucun log enregistré.</div>}
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 gap-2 pt-2">
+          <button
+            onClick={() => diagnostics.exportIncidentReport('private')}
+            className="bg-yellow-400 text-black rounded-lg px-3 py-2 font-semibold hover:bg-yellow-300 flex items-center justify-center gap-2"
+          >
+            <Download className="w-4 h-4" /> Export incident (privé)
+          </button>
+          <button
+            onClick={() => diagnostics.exportIncidentReport('public')}
+            className="bg-gray-100 text-black rounded-lg px-3 py-2 font-semibold hover:bg-white flex items-center justify-center gap-2"
+          >
+            <Shield className="w-4 h-4" /> Export incident (public, masqué)
+          </button>
+        </div>
+
+        <div className="text-xs text-amber-300/90 flex gap-2 items-start">
+          <AlertTriangle className="w-4 h-4 mt-0.5" />
+          Le mode public masque automatiquement les champs sensibles (token, secret, email, key, user_id...).
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -1,9 +1,9 @@
-import { Github, Lightbulb } from 'lucide-react';
+import { Activity, Github, Lightbulb } from 'lucide-react';
 import { UserMenu } from '../UserMenu';
 import { useAppState } from '../../context/AppStateContext';
 
 export function Navbar() {
-  const { profile, openAuthModal } = useAppState();
+  const { profile, openAuthModal, diagnostics } = useAppState();
 
   return (
     <nav className="fixed top-0 left-0 right-0 z-50 bg-black/50 backdrop-blur-lg">
@@ -20,6 +20,15 @@ export function Navbar() {
             <Github className="mr-2 w-4 h-4" />
             GitHub
           </a>
+
+          <button
+            onClick={diagnostics.toggle}
+            className="hover:text-yellow-400 transition-colors flex items-center"
+          >
+            <Activity className="mr-2 w-4 h-4" />
+            Diagnostics
+          </button>
+
           {profile ? (
             <UserMenu profile={profile} />
           ) : (

--- a/src/context/AppStateContext.tsx
+++ b/src/context/AppStateContext.tsx
@@ -1,4 +1,6 @@
 import { createContext, useContext, type ReactNode } from 'react';
+import type { RuntimeStatus } from '../../desktop/ipc/contracts';
+import type { ObservabilitySnapshot } from '../lib/observability';
 import type { Profile } from '../lib/supabase';
 
 interface PlaybackState {
@@ -21,6 +23,14 @@ interface VirtualStageState {
   nextPreset: () => void;
 }
 
+interface DiagnosticsState {
+  isOpen: boolean;
+  toggle: () => void;
+  snapshot: ObservabilitySnapshot;
+  runtimeStatus: RuntimeStatus;
+  exportIncidentReport: (scope: 'private' | 'public') => void;
+}
+
 interface AppStateValue {
   profile: Profile | null;
   isAuthModalOpen: boolean;
@@ -30,6 +40,7 @@ interface AppStateValue {
   toggleEffectPanel: () => void;
   playback: PlaybackState;
   virtualStage: VirtualStageState;
+  diagnostics: DiagnosticsState;
 }
 
 const AppStateContext = createContext<AppStateValue | null>(null);

--- a/src/hooks/usePlaybackState.ts
+++ b/src/hooks/usePlaybackState.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { observability } from '../lib/observability';
 
 interface UsePlaybackStateOptions {
   effectsCount: number;
@@ -20,7 +21,25 @@ export function usePlaybackState({
   useEffect(() => {
     if (!isPlaying) return;
 
+    let expectedAt = performance.now() + 100;
+
     const interval = window.setInterval(() => {
+      const now = performance.now();
+      const latency = now - expectedAt;
+      const droppedFrame = latency > 120;
+
+      observability.trackFrame(latency, droppedFrame);
+
+      if (droppedFrame) {
+        observability.warn('playback', 'Frame scheduling drift exceeded threshold', {
+          expectedAt,
+          actualAt: now,
+          latencyMs: Number(latency.toFixed(2))
+        });
+      }
+
+      expectedAt += 100;
+
       setCurrentTime((prevTime) => {
         const newTime = (prevTime + 1) % 100;
 
@@ -28,6 +47,7 @@ export function usePlaybackState({
           setCurrentEffect((prevEffect) => {
             const nextEffect = (prevEffect + 1) % effectsCount;
             onEffectAdvanced?.(nextEffect);
+            observability.info('playback', 'Effect advanced', { from: prevEffect, to: nextEffect });
             return nextEffect;
           });
         }
@@ -44,6 +64,9 @@ export function usePlaybackState({
   const togglePlay = () => {
     setIsPlaying((prev) => {
       const nextIsPlaying = !prev;
+      observability.info('playback', nextIsPlaying ? 'Playback started' : 'Playback paused', {
+        currentEffect,
+      });
       if (nextIsPlaying) {
         onPlayStart?.(currentEffect);
       }

--- a/src/lib/observability.ts
+++ b/src/lib/observability.ts
@@ -1,0 +1,205 @@
+export type ObservabilityLevel = 'debug' | 'info' | 'warn' | 'error';
+
+export interface ObservabilityLogEntry {
+  id: string;
+  timestamp: string;
+  level: ObservabilityLevel;
+  module: string;
+  message: string;
+  sessionId: string;
+  showId: string;
+  data?: Record<string, unknown>;
+}
+
+export interface RuntimeMetricsSnapshot {
+  frameLatencyMsAvg: number;
+  frameLatencyMsP95: number;
+  droppedFrames: number;
+  totalFrames: number;
+  protocolQueueDepth: number;
+  protocolQueueHighWatermark: number;
+  protocolDroppedFrames: number;
+}
+
+export interface ObservabilitySnapshot {
+  sessionId: string;
+  showId: string;
+  logs: ObservabilityLogEntry[];
+  metrics: RuntimeMetricsSnapshot;
+  updatedAt: string;
+}
+
+const LOG_LIMIT = 400;
+const LATENCY_SAMPLE_LIMIT = 240;
+
+const randomId = (): string =>
+  typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+
+const percentile = (samples: number[], p: number): number => {
+  if (samples.length === 0) {
+    return 0;
+  }
+
+  const sorted = [...samples].sort((a, b) => a - b);
+  const index = Math.min(sorted.length - 1, Math.max(0, Math.round((sorted.length - 1) * p)));
+  return Number(sorted[index].toFixed(2));
+};
+
+class ObservabilityStore {
+  private readonly sessionId = randomId();
+  private showId = 'default-show';
+  private logs: ObservabilityLogEntry[] = [];
+  private latencySamples: number[] = [];
+  private droppedFrames = 0;
+  private totalFrames = 0;
+  private protocolQueueDepth = 0;
+  private protocolQueueHighWatermark = 0;
+  private protocolDroppedFrames = 0;
+
+  setShowId(showId: string): void {
+    this.showId = showId;
+  }
+
+  log(level: ObservabilityLevel, module: string, message: string, data?: Record<string, unknown>): void {
+    const entry: ObservabilityLogEntry = {
+      id: randomId(),
+      timestamp: new Date().toISOString(),
+      level,
+      module,
+      message,
+      sessionId: this.sessionId,
+      showId: this.showId,
+      data,
+    };
+
+    this.logs = [entry, ...this.logs].slice(0, LOG_LIMIT);
+
+    if (level === 'error') {
+      console.error('[OBS]', entry);
+    } else if (level === 'warn') {
+      console.warn('[OBS]', entry);
+    } else {
+      console.info('[OBS]', entry);
+    }
+  }
+
+  trackFrame(frameLatencyMs: number, dropped = false): void {
+    this.totalFrames += 1;
+    if (dropped) {
+      this.droppedFrames += 1;
+    }
+
+    this.latencySamples = [...this.latencySamples, Math.max(0, frameLatencyMs)].slice(-LATENCY_SAMPLE_LIMIT);
+  }
+
+  setProtocolMetrics(metrics: {
+    queueDepth: number;
+    queueHighWatermark: number;
+    droppedFrames: number;
+  }): void {
+    this.protocolQueueDepth = metrics.queueDepth;
+    this.protocolQueueHighWatermark = metrics.queueHighWatermark;
+    this.protocolDroppedFrames = metrics.droppedFrames;
+  }
+
+  snapshot(): ObservabilitySnapshot {
+    const latencyAvg =
+      this.latencySamples.length > 0
+        ? Number(
+            (
+              this.latencySamples.reduce((total, sample) => total + sample, 0) / this.latencySamples.length
+            ).toFixed(2),
+          )
+        : 0;
+
+    return {
+      sessionId: this.sessionId,
+      showId: this.showId,
+      logs: this.logs,
+      metrics: {
+        frameLatencyMsAvg: latencyAvg,
+        frameLatencyMsP95: percentile(this.latencySamples, 0.95),
+        droppedFrames: this.droppedFrames,
+        totalFrames: this.totalFrames,
+        protocolQueueDepth: this.protocolQueueDepth,
+        protocolQueueHighWatermark: this.protocolQueueHighWatermark,
+        protocolDroppedFrames: this.protocolDroppedFrames,
+      },
+      updatedAt: new Date().toISOString(),
+    };
+  }
+}
+
+const store = new ObservabilityStore();
+
+export const observability = {
+  setShowId: (showId: string) => store.setShowId(showId),
+  debug: (module: string, message: string, data?: Record<string, unknown>) => store.log('debug', module, message, data),
+  info: (module: string, message: string, data?: Record<string, unknown>) => store.log('info', module, message, data),
+  warn: (module: string, message: string, data?: Record<string, unknown>) => store.log('warn', module, message, data),
+  error: (module: string, message: string, data?: Record<string, unknown>) => store.log('error', module, message, data),
+  trackFrame: (frameLatencyMs: number, dropped = false) => store.trackFrame(frameLatencyMs, dropped),
+  setProtocolMetrics: (metrics: {
+    queueDepth: number;
+    queueHighWatermark: number;
+    droppedFrames: number;
+  }) => store.setProtocolMetrics(metrics),
+  snapshot: (): ObservabilitySnapshot => store.snapshot(),
+};
+
+const SENSITIVE_KEYS = [/password/i, /secret/i, /token/i, /authorization/i, /^key$/i, /email/i, /user[_-]?id/i];
+
+const sanitize = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map(sanitize);
+  }
+
+  if (value && typeof value === 'object') {
+    const output: Record<string, unknown> = {};
+    for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
+      if (SENSITIVE_KEYS.some((matcher) => matcher.test(key))) {
+        output[key] = '[REDACTED]';
+      } else {
+        output[key] = sanitize(nested);
+      }
+    }
+    return output;
+  }
+
+  return value;
+};
+
+const APP_VERSION = import.meta.env.VITE_APP_VERSION ?? 'dev';
+
+export const buildIncidentReport = (options: {
+  exportScope: 'private' | 'public';
+  runtimeStatus: unknown;
+  appConfig: Record<string, unknown>;
+}): string => {
+  const snapshot = observability.snapshot();
+  const payload = {
+    generatedAt: new Date().toISOString(),
+    scope: options.exportScope,
+    appVersion: APP_VERSION,
+    diagnostics: {
+      ...snapshot,
+      logs: options.exportScope === 'public' ? (sanitize(snapshot.logs) as ObservabilityLogEntry[]) : snapshot.logs,
+    },
+    runtimeStatus: options.exportScope === 'public' ? sanitize(options.runtimeStatus) : options.runtimeStatus,
+    config: options.exportScope === 'public' ? sanitize(options.appConfig) : options.appConfig,
+  };
+
+  return JSON.stringify(payload, null, 2);
+};
+
+export const downloadIncidentReport = (filename: string, report: string): void => {
+  const blob = new Blob([report], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.click();
+  URL.revokeObjectURL(url);
+};

--- a/src/lib/runtimeClient.ts
+++ b/src/lib/runtimeClient.ts
@@ -11,7 +11,12 @@ import type {
 const fallbackStatus: RuntimeStatus = {
   ready: false,
   connectedDeviceId: null,
-  protocol: null
+  protocol: null,
+  metrics: {
+    protocolQueueDepth: 0,
+    protocolQueueHighWatermark: 0,
+    protocolDroppedFrames: 0
+  }
 };
 
 const unavailableError =


### PR DESCRIPTION
### Motivation
- Fournir une observabilité exploitable pour diagnostiquer incidents terrain: logs structurés (niveau/module/session/show), métriques runtime (latence frames, dropped frames, file d’envoi protocole) et un moyen simple d’exporter un rapport d’incident.
- Permettre aux équipes support de récupérer un snapshot contextualisé de l’app (logs + runtime + config + version) tout en masquant les données sensibles pour les exports publics.

### Description
- Ajout d’un module d’observabilité `src/lib/observability.ts` exposant `observability` (méthodes `debug|info|warn|error`, `trackFrame`, `setProtocolMetrics`, `snapshot`, `buildIncidentReport`, `downloadIncidentReport`) avec buffer de logs, échantillonnage latence et redaction des champs sensibles pour exports publics.
- Instrumentation du runtime et playback: `src/hooks/usePlaybackState.ts` enregistre la dérive de scheduling et les frames droppées via `observability.trackFrame`, et `src/App.tsx` initialise `observability` au boot et poll le `runtimeClient` pour mettre à jour les métriques protocole.
- UI de support: nouveau panneau `Diagnostics` dans `src/components/layout/DiagnosticsPanel.tsx` affichant session/show, état runtime (queue depth / watermark / dropped), métriques de frames et derniers logs, avec boutons d’export privé/public appelant `buildIncidentReport`.
- Exposition contrôles diagnostics: ajout de l’état `diagnostics` au contexte global `src/context/AppStateContext.tsx` et ajout d’un accès rapide `Diagnostics` dans la `Navbar`.
- Extensions IPC / runtime natif: `desktop/ipc/contracts.ts`, `desktop/native/hardwareRuntime.ts` et `src/lib/runtimeClient.ts` étendent `RuntimeStatus` pour inclure `metrics` (`protocolQueueDepth`, `protocolQueueHighWatermark`, `protocolDroppedFrames`) et la runtime mock met à jour ces métriques.

### Testing
- `npm run build` a été exécuté et a réussi (production build généré sans erreurs).
- `npm run lint` a été exécuté et signale des problèmes préexistants dans le repo (non introduits par ce patch); les fichiers modifiés ont été vérifiés séparément.
- `npx eslint` ciblant les fichiers modifiés a été exécuté et n’a retourné qu’un avertissement existant (`react-refresh/only-export-components` dans `AppStateContext.tsx`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d32fe54a18832a939791c92450f4c0)