### PR TITLE
Add automated test suites (unit/integration/e2e/perf) and CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm run test:ci

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "desktop:dev": "npm run dev --prefix desktop",
-    "desktop:build": "npm run build --prefix desktop"
+    "desktop:build": "npm run build --prefix desktop",
+    "test": "node scripts/run-tests.mjs",
+    "test:ci": "node scripts/run-tests.mjs"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.39.3",

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1,0 +1,24 @@
+import { build } from 'esbuild';
+import { pathToFileURL } from 'node:url';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const tempDir = await mkdtemp(join(tmpdir(), 'lightai-tests-'));
+
+try {
+  const outputFile = join(tempDir, 'tests.bundle.mjs');
+  await build({
+    entryPoints: ['tests/index.ts'],
+    bundle: true,
+    format: 'esm',
+    platform: 'node',
+    sourcemap: 'inline',
+    outfile: outputFile,
+    logLevel: 'silent',
+  });
+
+  await import(pathToFileURL(outputFile).href);
+} finally {
+  await rm(tempDir, { recursive: true, force: true });
+}

--- a/tests/e2e/show-workflow.e2e.test.ts
+++ b/tests/e2e/show-workflow.e2e.test.ts
@@ -1,0 +1,77 @@
+import { test, assert } from '../harness';
+import { FixtureProfileRegistry } from '../../src/core/fixtures/registry';
+import { FixturePatchEditor } from '../../src/core/fixtures/patch-editor';
+import { patchRenderMappingToShowStateUniverses } from '../../src/core/fixtures/engine-mapper';
+import { ShowController } from '../../src/core/show/controller';
+import type { ShowTimeline } from '../../src/core/show/types';
+
+test('Workflow critique: patch -> cue -> go -> blackout', () => {
+  const registry = new FixtureProfileRegistry();
+  registry.importProfiles([
+    {
+      format: 'lightai.fixture.v1',
+      manufacturer: 'LightAI',
+      model: 'Dimmer4',
+      profileId: 'lightai-dimmer4',
+      modes: [
+        {
+          id: '4ch',
+          name: '4-channel',
+          channels: [
+            { key: 'dim1', name: 'Dim 1', type: 'intensity', defaultValue: 20 },
+            { key: 'dim2', name: 'Dim 2', type: 'intensity', defaultValue: 30 },
+            { key: 'dim3', name: 'Dim 3', type: 'intensity', defaultValue: 40 },
+            { key: 'dim4', name: 'Dim 4', type: 'intensity', defaultValue: 50 },
+          ],
+        },
+      ],
+    },
+  ]);
+
+  const patch = new FixturePatchEditor(registry);
+  patch.upsertFixture({
+    id: 'fx-1',
+    name: 'Face',
+    profileId: 'lightai-dimmer4',
+    modeId: '4ch',
+    universe: 1,
+    address: 1,
+  });
+
+  const mapping = patch.buildRenderMapping();
+  const universes = patchRenderMappingToShowStateUniverses(mapping);
+  assert.equal(universes['1'].channels[1], 20);
+  assert.equal(universes['1'].channels[4], 50);
+
+  const timeline: ShowTimeline = {
+    version: 1,
+    entryCueId: 'intro',
+    output: { activeDriver: 'simulator', simulator: { kind: 'simulator' } },
+    chases: {},
+    scenes: {
+      introScene: {
+        id: 'introScene',
+        name: 'Intro',
+        values: [{ universeId: '1', channel: 1, value: 180 }],
+      },
+    },
+    cues: {
+      intro: {
+        id: 'intro',
+        name: 'Intro Cue',
+        sceneId: 'introScene',
+        transition: { fadeInMs: 0, holdMs: 2000, fadeOutMs: 0, follow: 'hold' },
+      },
+    },
+  };
+
+  const controller = new ShowController(timeline);
+  const goSnapshot = controller.go(0);
+
+  assert.equal(goSnapshot.activeCueId, 'intro');
+  assert.equal(goSnapshot.values['1:1'], 180);
+
+  const blackoutSnapshot = controller.blackout(500);
+  assert.equal(blackoutSnapshot.blackout, true);
+  assert.equal(blackoutSnapshot.values['1:1'], 0);
+});

--- a/tests/harness.ts
+++ b/tests/harness.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+
+type TestCase = {
+  name: string;
+  fn: () => void | Promise<void>;
+};
+
+const testCases: TestCase[] = [];
+
+export const test = (name: string, fn: () => void | Promise<void>): void => {
+  testCases.push({ name, fn });
+};
+
+export { assert };
+
+export const run = async (): Promise<void> => {
+  const failures: Array<{ name: string; error: unknown }> = [];
+
+  for (const testCase of testCases) {
+    try {
+      await testCase.fn();
+      console.log(`✓ ${testCase.name}`);
+    } catch (error) {
+      failures.push({ name: testCase.name, error });
+      console.error(`✗ ${testCase.name}`);
+      console.error(error);
+    }
+  }
+
+  if (failures.length > 0) {
+    throw new Error(`${failures.length} test(s) failed`);
+  }
+
+  console.log(`\n${testCases.length} test(s) passed.`);
+};

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -1,0 +1,7 @@
+import './unit/lighting-engine.unit.test';
+import './integration/protocols.integration.test';
+import './e2e/show-workflow.e2e.test';
+import './perf/performance.nonregression.test';
+import { run } from './harness';
+
+await run();

--- a/tests/integration/protocols.integration.test.ts
+++ b/tests/integration/protocols.integration.test.ts
@@ -1,0 +1,52 @@
+import { test, assert } from '../harness';
+import { ArtNetOutputDriver } from '../../src/core/protocols/drivers/artnet';
+import { OscOutputDriver } from '../../src/core/protocols/drivers/osc';
+
+test('Art-Net simulator: envoi packet avec en-tête et univers correct', async () => {
+  const sent: Array<{ packet: Uint8Array; port: number; host: string }> = [];
+  const driver = new ArtNetOutputDriver(
+    { kind: 'artnet', host: '127.0.0.1', port: 6454 },
+    {
+      transport: {
+        send: async (packet, port, host) => {
+          sent.push({ packet, port, host });
+        },
+      },
+    },
+  );
+
+  await driver.sendUniverse(2, [1, 2, 3]);
+
+  assert.equal(sent.length, 1);
+  assert.equal(sent[0].host, '127.0.0.1');
+  assert.equal(sent[0].port, 6454);
+  const header = String.fromCharCode(...sent[0].packet.slice(0, 8));
+  assert.equal(header, 'Art-Net\0');
+  assert.equal(sent[0].packet[14], 2);
+});
+
+test('OSC simulator: mapping adresse par univers', async () => {
+  const messages: Array<{ targetUrl: string; address: string; args: number[] }> = [];
+  const driver = new OscOutputDriver(
+    {
+      kind: 'osc',
+      targetUrl: 'udp://127.0.0.1:9000',
+      defaultAddress: '/lighting/default',
+      universeAddressMap: { 3: '/lighting/u3' },
+    },
+    {
+      transport: {
+        send: async (targetUrl, message) => {
+          messages.push({ targetUrl, address: message.address, args: [...message.args] });
+        },
+      },
+    },
+  );
+
+  await driver.sendUniverse(3, [12.2, 256]);
+  await driver.sendUniverse(1, [8]);
+
+  assert.equal(messages[0].address, '/lighting/u3');
+  assert.deepEqual(messages[0].args, [12, 255]);
+  assert.equal(messages[1].address, '/lighting/default');
+});

--- a/tests/perf/performance.nonregression.test.ts
+++ b/tests/perf/performance.nonregression.test.ts
@@ -1,0 +1,53 @@
+import { test, assert } from '../harness';
+import { FixtureProfileRegistry } from '../../src/core/fixtures/registry';
+import { FixturePatchEditor } from '../../src/core/fixtures/patch-editor';
+import { patchRenderMappingToShowStateUniverses } from '../../src/core/fixtures/engine-mapper';
+import { showStateToUniverseFrames } from '../../src/core/protocols/selector';
+
+const PERF_FIXTURES = 1000;
+
+test('Non-régression perf: charge fixtures/universes', () => {
+  const registry = new FixtureProfileRegistry();
+  registry.importProfiles([
+    {
+      format: 'lightai.fixture.v1',
+      manufacturer: 'Bench',
+      model: 'Fixture-8ch',
+      profileId: 'bench-8ch',
+      modes: [
+        {
+          id: '8ch',
+          name: '8-channel',
+          channels: Array.from({ length: 8 }, (_, idx) => ({
+            key: `c${idx + 1}`,
+            name: `Channel ${idx + 1}`,
+            type: 'intensity' as const,
+            defaultValue: idx * 10,
+          })),
+        },
+      ],
+    },
+  ]);
+
+  const patch = new FixturePatchEditor(registry);
+  for (let index = 0; index < PERF_FIXTURES; index += 1) {
+    patch.upsertFixture({
+      id: `fx-${index}`,
+      name: `Fixture ${index}`,
+      profileId: 'bench-8ch',
+      modeId: '8ch',
+      universe: Math.floor(index / 60) + 1,
+      address: (index % 60) * 8 + 1,
+    });
+  }
+
+  const startedAt = Date.now();
+  const mapping = patch.buildRenderMapping();
+  const universes = patchRenderMappingToShowStateUniverses(mapping);
+  const frames = showStateToUniverseFrames({ universes });
+  const elapsedMs = Date.now() - startedAt;
+
+  assert.equal(Object.keys(frames).length > 0, true);
+  assert.equal(mapping.channelMappings.length, PERF_FIXTURES * 8);
+  assert.ok(elapsedMs < 1500, `Perf budget dépassé: ${elapsedMs}ms (max 1500ms)`);
+});

--- a/tests/unit/lighting-engine.unit.test.ts
+++ b/tests/unit/lighting-engine.unit.test.ts
@@ -1,0 +1,78 @@
+import { test, assert } from '../harness';
+import { FrameScheduler } from '../../src/core/lighting-engine/scheduler';
+import { createInitialShowRunState, evaluateTimeline } from '../../src/core/show/executor';
+import { patchRenderMappingToShowStateUniverses } from '../../src/core/fixtures/engine-mapper';
+import { showStateToUniverseFrames } from '../../src/core/protocols/selector';
+import type { ShowTimeline } from '../../src/core/show/types';
+
+test('FrameScheduler traite les ticks en rattrapage', () => {
+  let now = 0;
+  const ticks: number[] = [];
+  const scheduler = new FrameScheduler({
+    tickMs: 20,
+    onTick: (tickAt) => ticks.push(tickAt),
+    deps: {
+      now: () => now,
+      schedule: () => 1,
+      cancel: () => undefined,
+    },
+  });
+
+  scheduler.start(0);
+  now = 65;
+  const count = scheduler.step(now);
+
+  assert.equal(count, 3);
+  assert.deepEqual(ticks, [20, 40, 60]);
+});
+
+test('Transitions: fade in / hold / fade out dans evaluateTimeline', () => {
+  const timeline: ShowTimeline = {
+    version: 1,
+    entryCueId: 'cue-a',
+    output: { activeDriver: 'simulator', simulator: { kind: 'simulator' } },
+    chases: {},
+    scenes: {
+      s1: { id: 's1', name: 'Warm', values: [{ universeId: '1', channel: 1, value: 100 }] },
+    },
+    cues: {
+      'cue-a': {
+        id: 'cue-a',
+        name: 'A',
+        sceneId: 's1',
+        transition: { fadeInMs: 1000, holdMs: 1000, fadeOutMs: 1000, follow: 'hold' },
+      },
+    },
+  };
+
+  const baseState = createInitialShowRunState();
+  const playing = {
+    ...baseState,
+    playing: true,
+    anchorStartedAtMs: 0,
+    cursor: { cueId: 'cue-a', chaseId: null, chaseIndex: -1, elapsedMs: 0 },
+    historyCueIds: ['cue-a'],
+  };
+
+  const at500 = evaluateTimeline(timeline, playing, 500).snapshot.values['1:1'];
+  const at1500 = evaluateTimeline(timeline, playing, 1500).snapshot.values['1:1'];
+  const at2500 = evaluateTimeline(timeline, playing, 2500).snapshot.values['1:1'];
+
+  assert.equal(at500, 50);
+  assert.equal(at1500, 100);
+  assert.equal(at2500, 50);
+});
+
+test('Mapping canaux: PatchRenderMapping -> univers -> frames', () => {
+  const universes = patchRenderMappingToShowStateUniverses({
+    channelMappings: [],
+    universeFrames: {
+      1: [0, 128, 0, 255],
+      2: [10, 0],
+    },
+  });
+
+  const frames = showStateToUniverseFrames({ universes });
+  assert.deepEqual(frames[1], [0, 128, 0, 255]);
+  assert.deepEqual(frames[2], [10, 0]);
+});


### PR DESCRIPTION
### Motivation
- Provide automated coverage for the lighting engine and protocol drivers to prevent regressions and validate critical workflows. 
- Ensure tests run in CI before merges, and include a lightweight runner that does not add heavy test deps to the repo. 

### Description
- Add a minimal TypeScript test harness and esbuild-based runner (`tests/harness.ts`, `scripts/run-tests.mjs`, `tests/index.ts`) to bundle and execute tests in Node. 
- Add unit tests for scheduler tick behaviour, timeline transition blending, and patch->universe mapping (`tests/unit/lighting-engine.unit.test.ts`). 
- Add integration tests for Art‑Net and OSC drivers, an end-to-end workflow test (`patch -> cue -> go -> blackout`), and a performance non‑regression test for fixture/universe load (`tests/integration/*`, `tests/e2e/*`, `tests/perf/*`). 
- Wire test commands into `package.json` (`test` / `test:ci`) and add a mandatory CI workflow that runs `npm ci`, `npm run lint`, `npm run build` and `npm run test:ci` (`.github/workflows/ci.yml`).

### Testing
- Ran `npm run test:ci` which executed the new bundled tests and reported all tests passing (7 test(s) passed). 
- Ran `npm run build` which succeeded (Vite production build completed). 
- Ran `npm run lint` which failed due to pre-existing lint errors (3 errors, 4 warnings), notably in `src/lib/effects.ts` and some React hook warnings; lint must be addressed separately before CI will be fully green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d332cd93c0832abb084fbf62eb62da)