### PR TITLE
docs: add versioned user/admin/dev guides and refresh README status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,67 +1,52 @@
 # LightAI-Pro
 
-![LightAI-Pro Banner](https://yourimageurl.com)
+LightAI-Pro est une application de conduite lumière (web + desktop) orientée show timeline, pilotage protocolaire et opérations live.
 
-### Le Futur de l'Éclairage Scénique 🚀
+## État réel du projet (avril 2026)
 
-**LightAI-Pro** est un logiciel révolutionnaire propulsé par l'intelligence artificielle, conçu pour automatiser et optimiser la gestion des éclairages scéniques. Grâce à des algorithmes avancés d'IA et de machine learning, il permet de créer des ambiances lumineuses dynamiques, synchronisées et ultra-réactives.
+### Implémenté aujourd'hui
+- Interface React avec contrôle de playback, panneau diagnostics et gestion de profil.  
+- Noyau show timeline (scènes, cues, chases, transitions, blackout).  
+- Runtime desktop Electron avec frontière IPC sécurisée pour accès matériel/protocoles.  
+- Drivers/protocoles présents: DMX, Art-Net, OSC et simulateur (selon implémentation runtime).  
+- Observabilité (journalisation, incident report exportable).  
+- Socle tests: unitaires, intégration, e2e et non-régression performance.
 
-## 🎯 Fonctionnalités Principales
+### En cours / à confirmer
+- Validation hardware terrain de bout en bout pour tous les adaptateurs DMX USB.
+- Durcissement de la chaîne release desktop selon les environnements de distribution.
+- Stabilisation complète des workflows collaboration Supabase en production.
 
-- 🎛 **Contrôle intelligent** : Ajustement automatique des lumières en fonction du son, du mouvement et du contexte.
-- 🎼 **Synchronisation musicale** : Analyse en temps réel du rythme et de l’intensité pour adapter l’éclairage.
-- 📡 **Compatibilité universelle** : Supporte les protocoles DMX, Art-Net, et OSC.
-- 🎨 **Effets dynamiques IA** : Génération automatique de shows lumineux basés sur l’ambiance désirée.
-- 📊 **Tableau de bord intuitif** : Interface utilisateur moderne et ergonomique.
-- 🤖 **Apprentissage adaptatif** : L’IA apprend des préférences et optimise les configurations au fil du temps.
+## Documentation
 
+### Utilisateur
+- Quickstart: `docs/user/quickstart.md`
+- Procédures spectacle: `docs/user/live-ops.md`
 
+### Admin
+- Déploiement, mise à jour, backup: `docs/admin/deployment.md`
 
+### Dev
+- Contribution et conventions: `docs/dev/contributing.md`
+- Architecture runtime: `docs/architecture/runtime.md`
+- Chaîne de release: `docs/architecture/release-chain.md`
 
-## 🚀 Utilisation
+## Roadmap (mise à jour)
 
-1. Lancez le logiciel
-2. Connectez vos équipements DMX / Art-Net.
-3. Configurez vos scènes via l'interface intuitive.
-4. Profitez d'un éclairage intelligent optimisé par l'IA !
+### Priorité haute
+- Validation de compatibilité matériel (Art-Net + DMX USB) sur matrices de devices cibles.
+- Renforcement des tests d'intégration runtime/IPC en conditions de charge.
+- Industrialisation release (signature, notarization, rollback automatisé).
 
-## 📌 Roadmap
-- [ ] Ajout d’une API pour intégration externe
-- [ ] Version mobile pour contrôle à distance
-- [ ] Personnalisation avancée des algorithmes IA
+### Priorité moyenne
+- API externe versionnée pour intégration tierce.
+- Gouvernance avancée des rôles/projets en collaboration.
+- Outils de migration de formats show versionnés.
 
+### Priorité exploratoire
+- Contrôle distant mobile.
+- Timecode/synchronisation distribuée avancée.
+- Visualisation scène plus avancée.
 
-## 🧱 Chaîne de release desktop
-
-La chaîne de release Windows/macOS (build reproductible, signature/notarization, auto-update stable/beta, compatibilité projet, rollback) est documentée ici :
-
-- `docs/architecture/release-chain.md`
-
-## 🤝 Contribuer
-Les contributions sont les bienvenues ! Clonez le repo, proposez vos améliorations via des PRs et rejoignez la révolution de l’éclairage intelligent.
-
-## 📜 Licence
-Proprietaire - Tous droits révervés !
-
-## 📩 Contact
-Pour toute question ou collaboration : [florian.ribes@live.fr](mailto:florian.ribes@live.fr)
-
----
-_Illuminez vos spectacles avec **LightAI-Pro**, l’IA au service de la lumière !_ ✨
-
-
-## 🤝 Collaboration temps réel (Supabase)
-
-Le backend peut être étendu avec la migration SQL suivante :
-
-- `supabase/migrations/20260406100000_collaboration_backend.sql`
-
-Cette migration ajoute :
-
-1. Modèles `projects`, `team_members`, `roles`, `shared_shows` (avec versionning d'état).
-2. RLS orienté rôles (`owner`, `operator`, `viewer`).
-3. Synchronisation non destructive via `sync_project_live_state` / `sync_shared_show_state` (optimistic update + contrôle de version).
-4. Journal d'actions via `action_journal` + RPC `log_cue_action`.
-5. Lock live via `live_control_locks` + RPC `acquire_live_control_lock`, `heartbeat_live_control_lock`, `release_live_control_lock`.
-
-Un helper TypeScript est fourni dans `src/lib/liveCollaboration.ts` pour consommer ces RPC côté client.
+## Licence
+Propriétaire — Tous droits réservés.

--- a/docs/admin/deployment.md
+++ b/docs/admin/deployment.md
@@ -1,0 +1,67 @@
+# Déploiement administrateur (v0.1)
+
+> Version document: 0.1  
+> Dernière mise à jour: 2026-04-06
+
+## 1) Installation
+
+## Prérequis hôte
+- Windows 10/11 x64 ou macOS 13+.
+- Node.js 20+ pour build local.
+- Accès aux secrets de signature/notarization (si release).
+
+## Installer les dépendances
+```bash
+npm install
+npm install --prefix desktop
+```
+
+## Build web
+```bash
+npm run build
+```
+
+## Build desktop
+```bash
+npm run desktop:build
+```
+
+La chaîne de release détaillée (signature, auto-update, rollback) est documentée dans `docs/architecture/release-chain.md`.
+
+---
+
+## 2) Mise à jour
+
+## Stratégie
+- Maintenir deux canaux: `stable` et `beta`.
+- Valider compatibilité de projet avant promotion.
+- Publier notes de version systématiques.
+
+## Scripts utiles
+```bash
+node scripts/release/verify-project-compat.mjs
+node scripts/release/generate-release-notes.mjs
+```
+
+En cas d'incident de release:
+```bash
+node scripts/release/rollback-release.mjs
+```
+
+---
+
+## 3) Backup et restauration
+
+## Données à sauvegarder
+- Fichiers show (timeline + patch + output config).
+- Configuration opérateur locale.
+- Exports diagnostics critiques.
+
+## Politique recommandée
+- Backup avant chaque spectacle.
+- Rétention minimale: 30 jours.
+- Copie hors machine de régie (stockage externe/chiffré).
+
+## Test de restauration
+- Exécuter mensuellement un test complet de restauration sur machine de préproduction.
+- Vérifier ouverture show + lecture cue list + blackout.

--- a/docs/dev/contributing.md
+++ b/docs/dev/contributing.md
@@ -1,0 +1,73 @@
+# Contributing développeur (v0.1)
+
+> Version document: 0.1  
+> Dernière mise à jour: 2026-04-06
+
+Merci de contribuer à LightAI-Pro.
+
+## 1) Architecture (vue rapide)
+
+- `src/`: UI React + logique applicative côté renderer.
+- `src/core/`: moteurs fonctionnels (fixtures, show timeline, audio, protocol selector).
+- `desktop/`: runtime natif Electron (IPC + accès matériel/protocoles).
+- `tests/`: unit, integration, e2e et non-régression performance.
+
+Principe clé: la UI n'accède jamais directement au hardware. Toute opération device/protocole passe par l'IPC natif.
+
+---
+
+## 2) Conventions de code
+
+- TypeScript strict et typage explicite des contrats.
+- Modules courts, orientés domaine (`core/show`, `core/fixtures`, `core/protocols`).
+- Pas de logique hardware dans `src/`.
+- Logs structurés via les utilitaires d'observabilité.
+
+## Branch/commit
+- Branches: `feature/*`, `fix/*`, `chore/*`.
+- Commits impératifs et précis (ex: `docs: add user and admin operational guides`).
+
+---
+
+## 3) Setup local
+
+```bash
+npm install
+npm run dev
+```
+
+Tests:
+```bash
+npm test
+```
+
+Lint:
+```bash
+npm run lint
+```
+
+Desktop (dev):
+```bash
+npm run desktop:dev
+```
+
+---
+
+## 4) Tests attendus avant PR
+
+Minimum:
+1. `npm run lint`
+2. `npm test`
+
+Selon le scope:
+- Modifier `src/core/show/*` => vérifier les tests unitaires show/lighting.
+- Modifier protocoles/runtime => ajouter/adapter tests d'intégration.
+- Modifier perf critique => exécuter la non-régression performance.
+
+---
+
+## 5) Process PR
+
+- Décrire clairement le contexte, la solution et les risques.
+- Lister les commandes de test exécutées.
+- Ajouter les changements de documentation lorsque le comportement utilisateur change.

--- a/docs/user/live-ops.md
+++ b/docs/user/live-ops.md
@@ -1,0 +1,61 @@
+# Procédures live-ops (v0.1)
+
+> Version document: 0.1  
+> Dernière mise à jour: 2026-04-06
+
+## 1) Avant ouverture salle
+
+### T-60 min
+- Charger le show validé.
+- Vérifier patch et output protocolaire.
+- Faire un line-check des univers critiques.
+
+### T-30 min
+- Lancer un run technique de 2 à 3 cues clés.
+- Vérifier la latence perçue des commandes.
+- Contrôler l'absence de dropped frames dans Diagnostics.
+
+### T-10 min
+- Revenir à l'état d'accueil scène.
+- Armer la cue d'entrée.
+- Vérifier procédure incident (blackout + reprise).
+
+---
+
+## 2) Pendant spectacle
+
+## Règles opérateur
+- Une seule personne exécute les commandes GO/BACK.
+- Toute modification de patch en live est interdite sauf urgence validée.
+- Si anomalie: prioriser sécurité visuelle (blackout) puis diagnostic.
+
+## Commandes standard
+1. **GO**: avance selon la transition active.
+2. **PAUSE**: gèle l'évolution au temps courant.
+3. **BACK**: retour au cue précédent (historique).
+4. **JUMP CUE**: accès direct cue nominal.
+5. **BLACKOUT**: extinction prioritaire immédiate.
+
+---
+
+## 3) Gestion d'incident
+
+### Incident protocole (perte output)
+1. Blackout préventif si sortie incohérente.
+2. Vérifier statut runtime + connexion device.
+3. Tentative de reconnexion.
+4. Reprise sur cue sûre (intensité faible) puis retour conduite.
+
+### Incident applicatif
+1. Exporter un incident report (scope privé recommandé).
+2. Capturer timestamp + cue actif.
+3. Basculer sur plan B (console de secours si disponible).
+
+---
+
+## 4) Après spectacle
+
+- Sauvegarder l'état final du show.
+- Exporter les rapports diagnostics utiles.
+- Noter les écarts: cues imprécises, latence, incidents.
+- Préparer la version suivante du show (post-mortem technique).

--- a/docs/user/quickstart.md
+++ b/docs/user/quickstart.md
@@ -1,0 +1,79 @@
+# Quickstart utilisateur (v0.1)
+
+> Version document: 0.1  
+> Dernière mise à jour: 2026-04-06
+
+## 1) Préparer l'environnement
+
+### Prérequis
+- Node.js 20+ et npm.
+- Une interface compatible Art-Net ou DMX USB (runtime natif desktop).
+- (Optionnel) un compte Supabase pour les profils et l'historique d'effets.
+
+### Installer et démarrer
+```bash
+npm install
+npm run dev
+```
+
+Pour tester le shell desktop (runtime matériel):
+```bash
+npm run desktop:dev
+```
+
+---
+
+## 2) Connexion matériel
+
+Le runtime natif est responsable de la communication protocolaire (DMX/Art-Net/OSC) via IPC sécurisé.
+
+### Vérification rapide
+1. Ouvrir l'application desktop.
+2. Vérifier l'état runtime dans le panneau **Diagnostics**.
+3. Contrôler les métriques de file protocolaire (queue depth/dropped frames).
+
+### En cas d'échec de connexion
+- Vérifier le réseau local (Art-Net).
+- Vérifier le mapping univers/adresses du patch.
+- Reconnecter le device depuis le runtime (connect/disconnect).
+
+---
+
+## 3) Créer le patch
+
+Le patch est la base du show: fixtures, univers et canaux.
+
+Workflow recommandé:
+1. Ajouter les fixtures avec identifiant et type.
+2. Assigner `universeId` et adresse de départ.
+3. Valider les collisions d'adresses avant de lancer le playback.
+
+Bonnes pratiques:
+- Nommer les fixtures par zone (ex: `Face-Stage-L`, `Back-1`).
+- Garder des blocs d'adresses cohérents par famille de projecteurs.
+- Versionner le patch dans le show sauvegardé.
+
+---
+
+## 4) Premier show
+
+### Étapes minimales
+1. Créer les scènes de base (intensité/couleurs).
+2. Créer une cue list avec transitions (`fadeInMs`, `holdMs`, `fadeOutMs`).
+3. Définir l'`entryCueId`.
+4. Tester les commandes live: **Go**, **Pause**, **Back**, **Jump Cue**, **Blackout**.
+
+### Contrôle live
+- Toujours valider le **Blackout** avant la répétition.
+- Sur incident, exporter un incident report depuis **Diagnostics**.
+
+---
+
+## 5) Checklist « prêt plateau »
+
+- [ ] Runtime `ready = true`.
+- [ ] Device protocole connecté.
+- [ ] Patch sans collision.
+- [ ] Cue d'entrée valide.
+- [ ] Blackout testé.
+- [ ] Sauvegarde du show faite avant ouverture public.


### PR DESCRIPTION
### Motivation
- Provide versioned operational documentation for users, operators and developers to support live show workflows and deployments. 
- Capture and publish current project status in `README.md` so the repository reflects implemented capabilities versus roadmap priorities. 
- Centralize onboarding and contribution guidance to reduce friction for hardware validation, release operations and developer contributions. 

### Description
- Add user quickstart at `docs/user/quickstart.md` covering environment, hardware connection, patch workflow, first show and a pre-show checklist. 
- Add live operations guide at `docs/user/live-ops.md` containing pre-show, in-show and post-show procedures plus incident handling. 
- Add admin deployment guide at `docs/admin/deployment.md` with installation, build/update scripts and backup/restore recommendations. 
- Add developer contributing guide at `docs/dev/contributing.md` describing architecture, coding conventions, local setup and required tests, and update `README.md` to reflect the current implemented features and updated roadmap. 

### Testing
- Ran the automated test suite with `npm test`, which passed (`7 test(s) passed`). 
- Ran linting with `npm run lint`, which reported pre-existing warnings and errors (lint failed due to unrelated `src/lib/effects.ts` issues). 
- This PR contains documentation-only changes and does not modify runtime or functional code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d33917da88832abebcc6e10acd4bf3)