### PR TITLE
Add canonical show model (JSON/YAML) with console mappings and example shows

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ LightAI-Pro est l'application du futur de conduite lumière de scènes (web + de
 - Contribution et conventions: `docs/dev/contributing.md`
 - Architecture runtime: `docs/architecture/runtime.md`
 - Chaîne de release: `docs/architecture/release-chain.md`
+- Modèle canonique show (JSON/YAML + mapping consoles): `docs/architecture/show-canonical-model.md`
+
+
+### Exemples de show
+- Petit show canonique: `docs/examples/shows/small-show.yaml` (`.json`)
+- Show moyen canonique: `docs/examples/shows/medium-show.yaml` (`.json`)
 
 ## Roadmap (mise à jour)
 

--- a/docs/architecture/show-canonical-model.md
+++ b/docs/architecture/show-canonical-model.md
@@ -1,0 +1,133 @@
+# Modèle canonique show (JSON/YAML)
+
+Ce document définit un format de show **indépendant de la console** pour permettre:
+- la préparation unique d'un show,
+- l'export vers plusieurs consoles,
+- les tests de non-régression via fixtures de référence.
+
+## 1) Schéma canonique
+
+Le schéma TypeScript de référence est implémenté dans `src/core/show/canonical.ts`.
+Le payload peut être sérialisé en JSON ou YAML sans perte.
+
+### Champs obligatoires couverts
+- Univers/adresses DMX (`dmx.universes`, `dmx.fixtures[].universe/address`).
+- Modes de fixtures (`dmx.fixtureModes`).
+- Attributs (`attributesCatalog`) dont dimmer/couleur/position/gobo.
+- Groupes (`groups`).
+- Presets/Palettes (`palettes`).
+- Cues (`cues`).
+- Timing (`cues[].timing`).
+- Mapping console (`consoleMappings`).
+
+## 2) Exemple minimal (YAML)
+
+```yaml
+schemaVersion: 1.0.0
+metadata:
+  showId: club-2026
+  title: Club Night
+  bpm: 128
+dmx:
+  universes:
+    - id: 1
+      name: Stage Left
+  fixtureModes:
+    - id: wash-14ch
+      name: Wash 14ch
+      dmxFootprint: 14
+      attributes:
+        - attributeId: dimmer
+          channels: [1]
+          coarseChannel: 1
+        - attributeId: color.rgb
+          channels: [2,3,4]
+          coarseChannel: 2
+  fixtures:
+    - id: wash-1
+      name: Wash 1
+      fixtureType: led_wash
+      modeId: wash-14ch
+      universe: 1
+      address: 1
+attributesCatalog:
+  - id: dimmer
+    family: dimmer
+    label: Intensité
+  - id: color.rgb
+    family: color
+    label: RGB
+groups:
+  - id: front-wash
+    name: Front Wash
+    fixtureIds: [wash-1]
+palettes:
+  - id: col-blue
+    name: Bleu profond
+    kind: color
+    values:
+      - groupId: front-wash
+        attributes:
+          - attributeId: color.rgb
+            value: "#0033FF"
+            scale: percent
+cues:
+  - id: cue-1
+    number: "1"
+    name: Intro
+    timing:
+      inMs: 1500
+      outMs: 1000
+    parts:
+      - id: p1
+        targets:
+          - groupId: front-wash
+            paletteRefs: [col-blue]
+            values:
+              - attributeId: dimmer
+                value: 80
+                scale: percent
+consoleMappings:
+  - console: grandma3
+    naming:
+      groupPrefix: Group
+      palettePrefix: Preset
+    limitations:
+      maxUniverses: 250
+      unsupportedFeatures: []
+    granularity:
+      timing: 0.1s
+      values: mixed
+    translations:
+      - canonical: palettes.kind=color
+        consoleTerm: Color Preset
+```
+
+## 3) Mapping vers consoles cibles
+
+`consoleMappings[]` doit porter les différences fonctionnelles.
+
+### Convention proposée
+- `naming`: normalisation des noms/objets exportés.
+- `limitations`: limites du moteur cible (univers max, taille groupes, features absentes).
+- `granularity`: granularité timing/valeur réellement exportable.
+- `translations`: dictionnaire canonique -> terme console.
+
+### Exemples de limitations
+- Timing arrondi à 100 ms.
+- Pas de palettes “focus” natives (fallback vers valeurs brutes de cues).
+- Valeurs 16-bit downgradées en 8-bit sur certains paramètres.
+
+## 4) Règles de compatibilité
+
+1. Le modèle canonique reste le **source of truth**.
+2. L'export console ne doit jamais supprimer d'information sans warning explicite.
+3. Toute perte (arrondi timing, downgrade 16->8 bit, fusion d'objets) doit être journalisée.
+4. Les exemples de `docs/examples/shows/` servent de base de tests.
+
+## 5) Jeux d'exemples complets
+
+- Petit show: `docs/examples/shows/small-show.yaml` et `.json`
+- Show moyen: `docs/examples/shows/medium-show.yaml` et `.json`
+
+Ces deux jeux couvrent DMX/modes/attributs/groupes/palettes/cues/timing + mappings multi-console.

--- a/docs/examples/shows/medium-show.json
+++ b/docs/examples/shows/medium-show.json
@@ -1,0 +1,229 @@
+{
+  "schemaVersion": "1.0.0",
+  "metadata": {
+    "showId": "medium-tour-2026",
+    "title": "Medium Tour Show",
+    "bpm": 126
+  },
+  "dmx": {
+    "universes": [
+      { "id": 1, "name": "Front Truss" },
+      { "id": 2, "name": "Back Truss" },
+      { "id": 3, "name": "Floor Package" }
+    ],
+    "fixtureModes": [
+      {
+        "id": "wash-20ch",
+        "name": "Wash 20ch",
+        "dmxFootprint": 20,
+        "attributes": [
+          { "attributeId": "dimmer", "channels": [1], "coarseChannel": 1 },
+          { "attributeId": "color.cmy", "channels": [2, 3, 4], "coarseChannel": 2 },
+          { "attributeId": "pan", "channels": [5, 6], "coarseChannel": 5, "fineChannel": 6 },
+          { "attributeId": "tilt", "channels": [7, 8], "coarseChannel": 7, "fineChannel": 8 },
+          { "attributeId": "zoom", "channels": [9], "coarseChannel": 9 }
+        ]
+      },
+      {
+        "id": "beam-18ch",
+        "name": "Beam 18ch",
+        "dmxFootprint": 18,
+        "attributes": [
+          { "attributeId": "dimmer", "channels": [1], "coarseChannel": 1 },
+          { "attributeId": "color.wheel", "channels": [5], "coarseChannel": 5 },
+          { "attributeId": "pan", "channels": [2, 3], "coarseChannel": 2, "fineChannel": 3 },
+          { "attributeId": "tilt", "channels": [4, 6], "coarseChannel": 4, "fineChannel": 6 },
+          { "attributeId": "gobo.index", "channels": [7], "coarseChannel": 7 }
+        ]
+      }
+    ],
+    "fixtures": [
+      { "id": "w1", "name": "Wash 1", "fixtureType": "moving_wash", "modeId": "wash-20ch", "universe": 1, "address": 1, "tags": ["front"] },
+      { "id": "w2", "name": "Wash 2", "fixtureType": "moving_wash", "modeId": "wash-20ch", "universe": 1, "address": 21, "tags": ["front"] },
+      { "id": "w3", "name": "Wash 3", "fixtureType": "moving_wash", "modeId": "wash-20ch", "universe": 2, "address": 1, "tags": ["back"] },
+      { "id": "w4", "name": "Wash 4", "fixtureType": "moving_wash", "modeId": "wash-20ch", "universe": 2, "address": 21, "tags": ["back"] },
+      { "id": "b1", "name": "Beam 1", "fixtureType": "moving_beam", "modeId": "beam-18ch", "universe": 3, "address": 1, "tags": ["floor"] },
+      { "id": "b2", "name": "Beam 2", "fixtureType": "moving_beam", "modeId": "beam-18ch", "universe": 3, "address": 19, "tags": ["floor"] }
+    ]
+  },
+  "attributesCatalog": [
+    { "id": "dimmer", "family": "dimmer", "label": "Intensité" },
+    { "id": "color.cmy", "family": "color", "label": "CMY" },
+    { "id": "color.wheel", "family": "color", "label": "Roue couleur" },
+    { "id": "pan", "family": "position", "label": "Pan" },
+    { "id": "tilt", "family": "position", "label": "Tilt" },
+    { "id": "gobo.index", "family": "gobo", "label": "Gobo" },
+    { "id": "zoom", "family": "beam", "label": "Zoom" }
+  ],
+  "groups": [
+    { "id": "g-wash-all", "name": "Wash All", "fixtureIds": ["w1", "w2", "w3", "w4"] },
+    { "id": "g-beam-floor", "name": "Floor Beams", "fixtureIds": ["b1", "b2"] },
+    { "id": "g-front", "name": "Front Line", "fixtureIds": ["w1", "w2"] }
+  ],
+  "palettes": [
+    {
+      "id": "pal-color-warm",
+      "name": "Warm Wash",
+      "kind": "color",
+      "values": [
+        {
+          "groupId": "g-wash-all",
+          "attributes": [
+            { "attributeId": "color.cmy", "value": "C10 M35 Y80", "scale": "percent" }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "pal-color-cold",
+      "name": "Cold Beam",
+      "kind": "color",
+      "values": [
+        {
+          "groupId": "g-beam-floor",
+          "attributes": [
+            { "attributeId": "color.wheel", "value": 7, "scale": "colorWheelSlot" }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "pal-pos-audience",
+      "name": "Audience Sweep",
+      "kind": "position",
+      "values": [
+        {
+          "groupId": "g-beam-floor",
+          "attributes": [
+            { "attributeId": "pan", "value": 35, "scale": "percent" },
+            { "attributeId": "tilt", "value": 62, "scale": "percent" }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "pal-beam-tight",
+      "name": "Tight Beam",
+      "kind": "beam",
+      "values": [
+        {
+          "groupId": "g-beam-floor",
+          "attributes": [
+            { "attributeId": "zoom", "value": 15, "scale": "percent" }
+          ]
+        }
+      ]
+    }
+  ],
+  "cues": [
+    {
+      "id": "cue-1",
+      "number": "1",
+      "name": "House Open",
+      "timing": { "inMs": 2500, "outMs": 1500 },
+      "parts": [
+        {
+          "id": "p-main",
+          "targets": [
+            {
+              "groupId": "g-front",
+              "paletteRefs": ["pal-color-warm"],
+              "values": [
+                { "attributeId": "dimmer", "value": 60, "scale": "percent" }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "cue-2",
+      "number": "2",
+      "name": "Verse Look",
+      "timing": { "inMs": 1800, "outMs": 1200, "delayMs": 250 },
+      "parts": [
+        {
+          "id": "p-wash",
+          "targets": [
+            {
+              "groupId": "g-wash-all",
+              "paletteRefs": ["pal-color-warm"],
+              "values": [
+                { "attributeId": "dimmer", "value": 75, "scale": "percent" }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "p-beam",
+          "targets": [
+            {
+              "groupId": "g-beam-floor",
+              "paletteRefs": ["pal-color-cold", "pal-pos-audience", "pal-beam-tight"],
+              "values": [
+                { "attributeId": "gobo.index", "value": 2, "scale": "goboSlot" },
+                { "attributeId": "dimmer", "value": 90, "scale": "percent" }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "cue-3",
+      "number": "3",
+      "name": "Chorus Hit",
+      "timing": { "inMs": 350, "outMs": 450, "followMs": 8000 },
+      "parts": [
+        {
+          "id": "p-all",
+          "targets": [
+            {
+              "groupId": "g-wash-all",
+              "values": [
+                { "attributeId": "dimmer", "value": 100, "scale": "percent" }
+              ]
+            },
+            {
+              "groupId": "g-beam-floor",
+              "values": [
+                { "attributeId": "dimmer", "value": 100, "scale": "percent" },
+                { "attributeId": "gobo.index", "value": 5, "scale": "goboSlot" }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "consoleMappings": [
+    {
+      "console": "grandma3",
+      "naming": { "groupPrefix": "Group", "palettePrefix": "Preset", "cueListFormat": "Sequence %s" },
+      "limitations": { "maxUniverses": 250, "maxFixturesPerGroup": 999 },
+      "granularity": { "timing": "0.1s", "values": "mixed" },
+      "translations": [
+        { "canonical": "palettes.kind=beam", "consoleTerm": "Beam Preset" },
+        { "canonical": "cues.parts", "consoleTerm": "Cue Parts" }
+      ]
+    },
+    {
+      "console": "chamsys",
+      "naming": { "groupPrefix": "Group", "palettePrefix": "Palette", "cueListFormat": "Cue Stack %s" },
+      "limitations": { "maxUniverses": 64, "unsupportedFeatures": ["per-step 16bit timing"] },
+      "granularity": { "timing": "0.1s", "values": "8bit" },
+      "translations": [
+        { "canonical": "palettes.kind=position", "consoleTerm": "Position Palette" }
+      ]
+    },
+    {
+      "console": "eos",
+      "naming": { "groupPrefix": "Group", "palettePrefix": "Palette", "cueListFormat": "List %s" },
+      "limitations": { "maxUniverses": 63999 },
+      "granularity": { "timing": "frames", "values": "16bit" },
+      "translations": [
+        { "canonical": "groups", "consoleTerm": "Groups" }
+      ]
+    }
+  ]
+}

--- a/docs/examples/shows/medium-show.yaml
+++ b/docs/examples/shows/medium-show.yaml
@@ -1,0 +1,142 @@
+schemaVersion: 1.0.0
+metadata:
+  showId: medium-tour-2026
+  title: Medium Tour Show
+  bpm: 126
+dmx:
+  universes:
+    - { id: 1, name: Front Truss }
+    - { id: 2, name: Back Truss }
+    - { id: 3, name: Floor Package }
+  fixtureModes:
+    - id: wash-20ch
+      name: Wash 20ch
+      dmxFootprint: 20
+      attributes:
+        - { attributeId: dimmer, channels: [1], coarseChannel: 1 }
+        - { attributeId: color.cmy, channels: [2, 3, 4], coarseChannel: 2 }
+        - { attributeId: pan, channels: [5, 6], coarseChannel: 5, fineChannel: 6 }
+        - { attributeId: tilt, channels: [7, 8], coarseChannel: 7, fineChannel: 8 }
+        - { attributeId: zoom, channels: [9], coarseChannel: 9 }
+    - id: beam-18ch
+      name: Beam 18ch
+      dmxFootprint: 18
+      attributes:
+        - { attributeId: dimmer, channels: [1], coarseChannel: 1 }
+        - { attributeId: color.wheel, channels: [5], coarseChannel: 5 }
+        - { attributeId: pan, channels: [2, 3], coarseChannel: 2, fineChannel: 3 }
+        - { attributeId: tilt, channels: [4, 6], coarseChannel: 4, fineChannel: 6 }
+        - { attributeId: gobo.index, channels: [7], coarseChannel: 7 }
+  fixtures:
+    - { id: w1, name: Wash 1, fixtureType: moving_wash, modeId: wash-20ch, universe: 1, address: 1, tags: [front] }
+    - { id: w2, name: Wash 2, fixtureType: moving_wash, modeId: wash-20ch, universe: 1, address: 21, tags: [front] }
+    - { id: w3, name: Wash 3, fixtureType: moving_wash, modeId: wash-20ch, universe: 2, address: 1, tags: [back] }
+    - { id: w4, name: Wash 4, fixtureType: moving_wash, modeId: wash-20ch, universe: 2, address: 21, tags: [back] }
+    - { id: b1, name: Beam 1, fixtureType: moving_beam, modeId: beam-18ch, universe: 3, address: 1, tags: [floor] }
+    - { id: b2, name: Beam 2, fixtureType: moving_beam, modeId: beam-18ch, universe: 3, address: 19, tags: [floor] }
+attributesCatalog:
+  - { id: dimmer, family: dimmer, label: Intensité }
+  - { id: color.cmy, family: color, label: CMY }
+  - { id: color.wheel, family: color, label: Roue couleur }
+  - { id: pan, family: position, label: Pan }
+  - { id: tilt, family: position, label: Tilt }
+  - { id: gobo.index, family: gobo, label: Gobo }
+  - { id: zoom, family: beam, label: Zoom }
+groups:
+  - { id: g-wash-all, name: Wash All, fixtureIds: [w1, w2, w3, w4] }
+  - { id: g-beam-floor, name: Floor Beams, fixtureIds: [b1, b2] }
+  - { id: g-front, name: Front Line, fixtureIds: [w1, w2] }
+palettes:
+  - id: pal-color-warm
+    name: Warm Wash
+    kind: color
+    values:
+      - groupId: g-wash-all
+        attributes:
+          - { attributeId: color.cmy, value: "C10 M35 Y80", scale: percent }
+  - id: pal-color-cold
+    name: Cold Beam
+    kind: color
+    values:
+      - groupId: g-beam-floor
+        attributes:
+          - { attributeId: color.wheel, value: 7, scale: colorWheelSlot }
+  - id: pal-pos-audience
+    name: Audience Sweep
+    kind: position
+    values:
+      - groupId: g-beam-floor
+        attributes:
+          - { attributeId: pan, value: 35, scale: percent }
+          - { attributeId: tilt, value: 62, scale: percent }
+  - id: pal-beam-tight
+    name: Tight Beam
+    kind: beam
+    values:
+      - groupId: g-beam-floor
+        attributes:
+          - { attributeId: zoom, value: 15, scale: percent }
+cues:
+  - id: cue-1
+    number: "1"
+    name: House Open
+    timing: { inMs: 2500, outMs: 1500 }
+    parts:
+      - id: p-main
+        targets:
+          - groupId: g-front
+            paletteRefs: [pal-color-warm]
+            values:
+              - { attributeId: dimmer, value: 60, scale: percent }
+  - id: cue-2
+    number: "2"
+    name: Verse Look
+    timing: { inMs: 1800, outMs: 1200, delayMs: 250 }
+    parts:
+      - id: p-wash
+        targets:
+          - groupId: g-wash-all
+            paletteRefs: [pal-color-warm]
+            values:
+              - { attributeId: dimmer, value: 75, scale: percent }
+      - id: p-beam
+        targets:
+          - groupId: g-beam-floor
+            paletteRefs: [pal-color-cold, pal-pos-audience, pal-beam-tight]
+            values:
+              - { attributeId: gobo.index, value: 2, scale: goboSlot }
+              - { attributeId: dimmer, value: 90, scale: percent }
+  - id: cue-3
+    number: "3"
+    name: Chorus Hit
+    timing: { inMs: 350, outMs: 450, followMs: 8000 }
+    parts:
+      - id: p-all
+        targets:
+          - groupId: g-wash-all
+            values:
+              - { attributeId: dimmer, value: 100, scale: percent }
+          - groupId: g-beam-floor
+            values:
+              - { attributeId: dimmer, value: 100, scale: percent }
+              - { attributeId: gobo.index, value: 5, scale: goboSlot }
+consoleMappings:
+  - console: grandma3
+    naming: { groupPrefix: Group, palettePrefix: Preset, cueListFormat: "Sequence %s" }
+    limitations: { maxUniverses: 250, maxFixturesPerGroup: 999 }
+    granularity: { timing: 0.1s, values: mixed }
+    translations:
+      - { canonical: "palettes.kind=beam", consoleTerm: "Beam Preset" }
+      - { canonical: "cues.parts", consoleTerm: "Cue Parts" }
+  - console: chamsys
+    naming: { groupPrefix: Group, palettePrefix: Palette, cueListFormat: "Cue Stack %s" }
+    limitations: { maxUniverses: 64, unsupportedFeatures: ["per-step 16bit timing"] }
+    granularity: { timing: 0.1s, values: 8bit }
+    translations:
+      - { canonical: "palettes.kind=position", consoleTerm: "Position Palette" }
+  - console: eos
+    naming: { groupPrefix: Group, palettePrefix: Palette, cueListFormat: "List %s" }
+    limitations: { maxUniverses: 63999 }
+    granularity: { timing: frames, values: 16bit }
+    translations:
+      - { canonical: "groups", consoleTerm: "Groups" }

--- a/docs/examples/shows/small-show.json
+++ b/docs/examples/shows/small-show.json
@@ -1,0 +1,132 @@
+{
+  "schemaVersion": "1.0.0",
+  "metadata": {
+    "showId": "small-demo-001",
+    "title": "Petit Show Demo",
+    "bpm": 120
+  },
+  "dmx": {
+    "universes": [
+      { "id": 1, "name": "Main" }
+    ],
+    "fixtureModes": [
+      {
+        "id": "spot-16ch",
+        "name": "Spot 16ch",
+        "dmxFootprint": 16,
+        "attributes": [
+          { "attributeId": "dimmer", "channels": [1], "coarseChannel": 1 },
+          { "attributeId": "color.wheel", "channels": [6], "coarseChannel": 6 },
+          { "attributeId": "pan", "channels": [2, 3], "coarseChannel": 2, "fineChannel": 3 },
+          { "attributeId": "tilt", "channels": [4, 5], "coarseChannel": 4, "fineChannel": 5 },
+          { "attributeId": "gobo.index", "channels": [7], "coarseChannel": 7 }
+        ]
+      }
+    ],
+    "fixtures": [
+      { "id": "s1", "name": "Spot 1", "fixtureType": "moving_spot", "modeId": "spot-16ch", "universe": 1, "address": 1 },
+      { "id": "s2", "name": "Spot 2", "fixtureType": "moving_spot", "modeId": "spot-16ch", "universe": 1, "address": 17 }
+    ]
+  },
+  "attributesCatalog": [
+    { "id": "dimmer", "family": "dimmer", "label": "Intensité" },
+    { "id": "color.wheel", "family": "color", "label": "Roue couleur" },
+    { "id": "pan", "family": "position", "label": "Pan" },
+    { "id": "tilt", "family": "position", "label": "Tilt" },
+    { "id": "gobo.index", "family": "gobo", "label": "Gobo" }
+  ],
+  "groups": [
+    { "id": "all-spots", "name": "All Spots", "fixtureIds": ["s1", "s2"] }
+  ],
+  "palettes": [
+    {
+      "id": "pal-color-blue",
+      "name": "Color Blue",
+      "kind": "color",
+      "values": [
+        {
+          "groupId": "all-spots",
+          "attributes": [
+            { "attributeId": "color.wheel", "value": 3, "scale": "colorWheelSlot" }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "pal-pos-center",
+      "name": "Position Center",
+      "kind": "position",
+      "values": [
+        {
+          "groupId": "all-spots",
+          "attributes": [
+            { "attributeId": "pan", "value": 50, "scale": "percent" },
+            { "attributeId": "tilt", "value": 50, "scale": "percent" }
+          ]
+        }
+      ]
+    }
+  ],
+  "cues": [
+    {
+      "id": "cue-1",
+      "number": "1",
+      "name": "Intro Blue",
+      "timing": { "inMs": 1000, "outMs": 500 },
+      "parts": [
+        {
+          "id": "part-main",
+          "targets": [
+            {
+              "groupId": "all-spots",
+              "paletteRefs": ["pal-color-blue", "pal-pos-center"],
+              "values": [
+                { "attributeId": "dimmer", "value": 70, "scale": "percent" },
+                { "attributeId": "gobo.index", "value": 1, "scale": "goboSlot" }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "cue-2",
+      "number": "2",
+      "name": "Hit White",
+      "timing": { "inMs": 250, "outMs": 250, "followMs": 4000 },
+      "parts": [
+        {
+          "id": "part-main",
+          "targets": [
+            {
+              "groupId": "all-spots",
+              "values": [
+                { "attributeId": "dimmer", "value": 100, "scale": "percent" }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "consoleMappings": [
+    {
+      "console": "grandma3",
+      "naming": { "groupPrefix": "Group", "palettePrefix": "Preset", "cueListFormat": "Main %s" },
+      "limitations": { "maxUniverses": 250 },
+      "granularity": { "timing": "0.1s", "values": "mixed" },
+      "translations": [
+        { "canonical": "palettes.kind=position", "consoleTerm": "Position Preset" }
+      ]
+    },
+    {
+      "console": "eos",
+      "naming": { "groupPrefix": "Group", "palettePrefix": "Palette", "cueListFormat": "List %s" },
+      "limitations": { "maxUniverses": 63999, "unsupportedFeatures": ["gobo shake macro"] },
+      "granularity": { "timing": "frames", "values": "16bit" },
+      "translations": [
+        { "canonical": "palettes.kind=color", "consoleTerm": "Color Palette" }
+      ]
+    }
+  ]
+}

--- a/docs/examples/shows/small-show.yaml
+++ b/docs/examples/shows/small-show.yaml
@@ -1,0 +1,108 @@
+schemaVersion: 1.0.0
+metadata:
+  showId: small-demo-001
+  title: Petit Show Demo
+  bpm: 120
+dmx:
+  universes:
+    - id: 1
+      name: Main
+  fixtureModes:
+    - id: spot-16ch
+      name: Spot 16ch
+      dmxFootprint: 16
+      attributes:
+        - attributeId: dimmer
+          channels: [1]
+          coarseChannel: 1
+        - attributeId: color.wheel
+          channels: [6]
+          coarseChannel: 6
+        - attributeId: pan
+          channels: [2,3]
+          coarseChannel: 2
+          fineChannel: 3
+        - attributeId: tilt
+          channels: [4,5]
+          coarseChannel: 4
+          fineChannel: 5
+        - attributeId: gobo.index
+          channels: [7]
+          coarseChannel: 7
+  fixtures:
+    - id: s1
+      name: Spot 1
+      fixtureType: moving_spot
+      modeId: spot-16ch
+      universe: 1
+      address: 1
+    - id: s2
+      name: Spot 2
+      fixtureType: moving_spot
+      modeId: spot-16ch
+      universe: 1
+      address: 17
+attributesCatalog:
+  - { id: dimmer, family: dimmer, label: Intensité }
+  - { id: color.wheel, family: color, label: Roue couleur }
+  - { id: pan, family: position, label: Pan }
+  - { id: tilt, family: position, label: Tilt }
+  - { id: gobo.index, family: gobo, label: Gobo }
+groups:
+  - id: all-spots
+    name: All Spots
+    fixtureIds: [s1, s2]
+palettes:
+  - id: pal-color-blue
+    name: Color Blue
+    kind: color
+    values:
+      - groupId: all-spots
+        attributes:
+          - { attributeId: color.wheel, value: 3, scale: colorWheelSlot }
+  - id: pal-pos-center
+    name: Position Center
+    kind: position
+    values:
+      - groupId: all-spots
+        attributes:
+          - { attributeId: pan, value: 50, scale: percent }
+          - { attributeId: tilt, value: 50, scale: percent }
+cues:
+  - id: cue-1
+    number: "1"
+    name: Intro Blue
+    timing: { inMs: 1000, outMs: 500 }
+    parts:
+      - id: part-main
+        targets:
+          - groupId: all-spots
+            paletteRefs: [pal-color-blue, pal-pos-center]
+            values:
+              - { attributeId: dimmer, value: 70, scale: percent }
+              - { attributeId: gobo.index, value: 1, scale: goboSlot }
+  - id: cue-2
+    number: "2"
+    name: Hit White
+    timing: { inMs: 250, outMs: 250, followMs: 4000 }
+    parts:
+      - id: part-main
+        targets:
+          - groupId: all-spots
+            values:
+              - { attributeId: dimmer, value: 100, scale: percent }
+consoleMappings:
+  - console: grandma3
+    naming: { groupPrefix: Group, palettePrefix: Preset, cueListFormat: "Main %s" }
+    limitations: { maxUniverses: 250 }
+    granularity: { timing: 0.1s, values: mixed }
+    translations:
+      - { canonical: "palettes.kind=position", consoleTerm: "Position Preset" }
+  - console: eos
+    naming: { groupPrefix: Group, palettePrefix: Palette, cueListFormat: "List %s" }
+    limitations:
+      maxUniverses: 63999
+      unsupportedFeatures: ["gobo shake macro"]
+    granularity: { timing: frames, values: 16bit }
+    translations:
+      - { canonical: "palettes.kind=color", consoleTerm: "Color Palette" }

--- a/src/core/show/canonical.ts
+++ b/src/core/show/canonical.ts
@@ -1,0 +1,120 @@
+export type CanonicalValueScale = 'byte' | 'fine16' | 'degrees' | 'percent' | 'kelvin' | 'colorWheelSlot' | 'goboSlot';
+
+export interface CanonicalAttributeValue {
+  attributeId: string;
+  value: number | string;
+  scale: CanonicalValueScale;
+}
+
+export interface CanonicalFixtureMode {
+  id: string;
+  name: string;
+  dmxFootprint: number;
+  attributes: Array<{
+    attributeId: string;
+    channels: number[];
+    coarseChannel: number;
+    fineChannel?: number;
+    defaultValue?: number;
+  }>;
+}
+
+export interface CanonicalFixture {
+  id: string;
+  name: string;
+  fixtureType: string;
+  manufacturer?: string;
+  modeId: string;
+  universe: number;
+  address: number;
+  tags?: string[];
+}
+
+export interface CanonicalGroup {
+  id: string;
+  name: string;
+  fixtureIds: string[];
+}
+
+export interface CanonicalPalette {
+  id: string;
+  name: string;
+  kind: 'color' | 'position' | 'beam' | 'intensity' | 'focus';
+  values: Array<{
+    fixtureId?: string;
+    groupId?: string;
+    attributes: CanonicalAttributeValue[];
+  }>;
+}
+
+export interface CanonicalCuePart {
+  id: string;
+  label?: string;
+  targets: Array<{
+    fixtureId?: string;
+    groupId?: string;
+    values: CanonicalAttributeValue[];
+    paletteRefs?: string[];
+  }>;
+}
+
+export interface CanonicalCueTiming {
+  inMs: number;
+  outMs?: number;
+  delayMs?: number;
+  followMs?: number;
+}
+
+export interface CanonicalCue {
+  id: string;
+  number: string;
+  name: string;
+  timing: CanonicalCueTiming;
+  parts: CanonicalCuePart[];
+}
+
+export interface CanonicalConsoleMapping {
+  console: 'grandma3' | 'eos' | 'chamsys' | 'avista';
+  naming: {
+    groupPrefix?: string;
+    palettePrefix?: string;
+    cueListFormat?: string;
+  };
+  limitations: {
+    maxUniverses?: number;
+    maxFixturesPerGroup?: number;
+    unsupportedFeatures?: string[];
+  };
+  granularity: {
+    timing: 'ms' | '0.1s' | 'frames';
+    values: '8bit' | '16bit' | 'mixed';
+  };
+  translations: Array<{
+    canonical: string;
+    consoleTerm: string;
+    note?: string;
+  }>;
+}
+
+export interface CanonicalShowModel {
+  schemaVersion: '1.0.0';
+  metadata: {
+    showId: string;
+    title: string;
+    bpm?: number;
+  };
+  dmx: {
+    universes: Array<{ id: number; name?: string; net?: number; subnet?: number }>;
+    fixtureModes: CanonicalFixtureMode[];
+    fixtures: CanonicalFixture[];
+  };
+  attributesCatalog: Array<{
+    id: string;
+    family: 'dimmer' | 'color' | 'position' | 'gobo' | 'beam' | 'focus';
+    label: string;
+  }>;
+  groups: CanonicalGroup[];
+  palettes: CanonicalPalette[];
+  cues: CanonicalCue[];
+  consoleMappings: CanonicalConsoleMapping[];
+}

--- a/src/core/show/index.ts
+++ b/src/core/show/index.ts
@@ -3,3 +3,5 @@ export * from './executor';
 export * from './controller';
 export * from './persistence';
 export * from './protocol-link';
+
+export * from './canonical';


### PR DESCRIPTION
### Motivation
- Introduire un modèle canonique indépendant de la console pour représenter un show (DMX, fixtures, attributs, palettes, cues, timing) afin d'avoir une source unique pour préparation, export et tests.
- Permettre d'exprimer différences et limitations spécifiques aux consoles cibles via un mapping formel pour sécuriser les exports.

### Description
- Ajout du schéma TypeScript canonique dans `src/core/show/canonical.ts` couvrant univers/adresses DMX, modes de fixture, attributs (dimmer/couleur/position/gobo...), groupes, palettes, cues, timing et `consoleMappings` (`naming`, `limitations`, `granularity`, `translations`).
- Exposition du module canonique via `export * from './canonical'` dans `src/core/show/index.ts`.
- Documentation de la spécification et des règles de compatibilité dans `docs/architecture/show-canonical-model.md`.
- Ajout de jeux d'exemples complets pour test/interop en YAML + JSON : `docs/examples/shows/small-show.{yaml,json}` et `docs/examples/shows/medium-show.{yaml,json}`.
- Mise à jour du `README.md` pour référencer la nouvelle documentation et les exemples.

### Testing
- L'ensemble des tests automatiques exécutés avec `npm run test -- --runInBand` a réussi (7 tests passés). 
- `npm run lint` a échoué en raison d'erreurs de lint préexistantes non liées à ce changement (notamment dans `src/lib/effects.ts`), et plusieurs warnings ont été signalés.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee0491c6dc832a8c5b508df97ac64c)