### PR TITLE
feat(fixtures): centralize fixture capabilities and normalize compatibility

### DIFF
--- a/src/core/fixtures/README.md
+++ b/src/core/fixtures/README.md
@@ -24,3 +24,14 @@ interface FixtureProfile {
 ```
 
 Le patch editor valide ensuite les collisions d'adresses et les débordements (1..512) avant de produire le mapping final (frames par univers) pour le moteur lumière.
+
+## API interne `fixture capabilities`
+
+Le module `capabilities.ts` centralise:
+
+- la normalisation des attributs hétérogènes (`ColorMix`, `RGBW`, alias pan/tilt, etc.),
+- les définitions de capacités consolidées (attributs, canaux, résolution 8/16 bits, plages),
+- les macros de mode et limitations explicites de mode,
+- les règles de compatibilité (attributs recommandés manquants, fallback coarse/fine, attributs indisponibles).
+
+Cette API est utilisée par le pipeline de conversion patch → show canonique pour homogénéiser les attributs entre modules IA et export consoles.

--- a/src/core/fixtures/capabilities.ts
+++ b/src/core/fixtures/capabilities.ts
@@ -1,0 +1,215 @@
+import type {
+  FixtureChannelDefinition,
+  FixtureChannelRange,
+  FixtureModeLimitations,
+  FixtureProfile,
+  FixtureProfileMode,
+} from './types';
+
+export const CANONICAL_ATTRIBUTE_ALIASES = {
+  dimmer: ['intensity', 'masterdimmer'],
+  red: ['r'],
+  green: ['g'],
+  blue: ['b'],
+  white: ['w'],
+  amber: ['a'],
+  uv: ['ultraviolet'],
+  rgb: ['colormix', 'colormixing', 'rgbmix'],
+  rgbw: ['colormixrgbw', 'rgbwcolor'],
+  pan: ['pancoarse'],
+  panFine: ['panfine', 'pan16', 'panmsb'],
+  tilt: ['tiltcoarse'],
+  tiltFine: ['tiltfine', 'tilt16', 'tiltmsb'],
+  strobe: ['shutter', 'strobeeffect'],
+} as const;
+
+const recommendedAttributes = ['dimmer'] as const;
+
+const aliasLookup = (() => {
+  const entries = new Map<string, string>();
+
+  Object.entries(CANONICAL_ATTRIBUTE_ALIASES).forEach(([canonical, aliases]) => {
+    entries.set(normalizeAttributeToken(canonical), canonical);
+    aliases.forEach((alias) => entries.set(normalizeAttributeToken(alias), canonical));
+  });
+
+  return entries;
+})();
+
+export interface FixtureAttributeCapability {
+  id: string;
+  label: string;
+  channels: number[];
+  resolutionBits: 8 | 16;
+  range: FixtureChannelRange;
+  sourceChannelKeys: string[];
+}
+
+export interface FixtureCapabilityCompatibility {
+  missingRecommendedAttributes: string[];
+  unavailableAttributes: string[];
+  degradedResolutions: Array<{
+    attribute: string;
+    requested: 16;
+    provided: 8;
+  }>;
+  modeLimitations: FixtureModeLimitations;
+}
+
+export interface FixtureCapabilities {
+  profileId: string;
+  modeId: string;
+  attributes: Record<string, FixtureAttributeCapability>;
+  macros: Array<{ id: string; name: string; channelKeys: string[] }>;
+  compatibility: FixtureCapabilityCompatibility;
+}
+
+function normalizeAttributeToken(value: string): string {
+  return value.replace(/[^a-z0-9]+/giu, '').toLowerCase();
+}
+
+export function normalizeFixtureAttributeName(value: string): string {
+  const normalized = normalizeAttributeToken(value);
+  return aliasLookup.get(normalized) ?? normalized;
+}
+
+const defaultRangeForChannel = (channel: FixtureChannelDefinition): FixtureChannelRange => {
+  if (channel.range) {
+    return channel.range;
+  }
+
+  if (channel.resolutionBits === 16) {
+    return { min: 0, max: 65535 };
+  }
+
+  return { min: 0, max: 255 };
+};
+
+const resolveChannelCanonicalAttribute = (channel: FixtureChannelDefinition): string => {
+  if (typeof channel.attribute === 'string' && channel.attribute.trim().length > 0) {
+    return normalizeFixtureAttributeName(channel.attribute);
+  }
+
+  const candidates = [channel.key, channel.name, ...(channel.aliases ?? [])];
+  for (const candidate of candidates) {
+    const normalized = normalizeFixtureAttributeName(candidate);
+    if (normalized.length > 0) {
+      return normalized;
+    }
+  }
+
+  return normalizeFixtureAttributeName(`${channel.type}.${channel.key}`);
+};
+
+export const getChannelAttributeId = (channel: FixtureChannelDefinition): string => {
+  const canonical = resolveChannelCanonicalAttribute(channel);
+  if (canonical === 'rgb' || canonical === 'rgbw') {
+    return `color.${canonical}`;
+  }
+
+  return `${channel.type}.${canonical}`;
+};
+
+export const getFixtureCapabilities = (
+  profile: FixtureProfile,
+  mode: FixtureProfileMode,
+): FixtureCapabilities => {
+  const attributes = new Map<string, FixtureAttributeCapability>();
+
+  mode.channels.forEach((channel, index) => {
+    const attributeId = getChannelAttributeId(channel);
+    const existing = attributes.get(attributeId);
+    const resolutionBits = channel.resolutionBits ?? 8;
+    const channelNumber = index + 1;
+
+    if (!existing) {
+      attributes.set(attributeId, {
+        id: attributeId,
+        label: channel.name,
+        channels: [channelNumber],
+        resolutionBits,
+        range: defaultRangeForChannel(channel),
+        sourceChannelKeys: [channel.key],
+      });
+      return;
+    }
+
+    existing.channels.push(channelNumber);
+    existing.sourceChannelKeys.push(channel.key);
+    existing.resolutionBits = existing.resolutionBits === 16 || resolutionBits === 16 ? 16 : 8;
+    existing.range = {
+      min: Math.min(existing.range.min, defaultRangeForChannel(channel).min),
+      max: Math.max(existing.range.max, defaultRangeForChannel(channel).max),
+    };
+  });
+
+  const availableCanonicalAttributes = [...attributes.values()].map((item) => item.id.split('.').at(1) ?? item.id);
+  const unavailableAttributes = (mode.limitations?.unsupportedAttributes ?? []).map(normalizeFixtureAttributeName);
+
+  const degradedResolutions = availableCanonicalAttributes
+    .filter((attribute) => attribute.endsWith('Fine'))
+    .filter((attribute) => !availableCanonicalAttributes.includes(attribute.replace(/Fine$/u, '')))
+    .map((attribute) => ({
+      attribute,
+      requested: 16 as const,
+      provided: 8 as const,
+    }));
+
+  return {
+    profileId: profile.profileId,
+    modeId: mode.id,
+    attributes: Object.fromEntries(attributes.entries()),
+    macros: (mode.macros ?? []).map((macro) => ({
+      id: macro.id,
+      name: macro.name,
+      channelKeys: [...macro.channelKeys],
+    })),
+    compatibility: {
+      missingRecommendedAttributes: recommendedAttributes
+        .map((attribute) => `intensity.${attribute}`)
+        .filter((attribute) => !attributes.has(attribute)),
+      unavailableAttributes,
+      degradedResolutions,
+      modeLimitations: {
+        unsupportedAttributes: mode.limitations?.unsupportedAttributes ?? [],
+        notes: mode.limitations?.notes ?? [],
+      },
+    },
+  };
+};
+
+export const mapRequestedAttributesToCapabilities = (
+  capabilities: FixtureCapabilities,
+  requestedAttributes: ReadonlyArray<string>,
+): {
+  supported: string[];
+  unsupported: string[];
+  degraded: Array<{ requested: string; fallback: string }>;
+} => {
+  const supported: string[] = [];
+  const unsupported: string[] = [];
+  const degraded: Array<{ requested: string; fallback: string }> = [];
+
+  requestedAttributes.forEach((requestedAttribute) => {
+    const normalized = normalizeFixtureAttributeName(requestedAttribute);
+    const directMatch = Object.keys(capabilities.attributes).find((attributeId) => attributeId.endsWith(`.${normalized}`));
+
+    if (directMatch) {
+      supported.push(directMatch);
+      return;
+    }
+
+    if (normalized.endsWith('fine')) {
+      const coarse = normalized.replace(/fine$/u, '');
+      const fallback = Object.keys(capabilities.attributes).find((attributeId) => attributeId.endsWith(`.${coarse}`));
+      if (fallback) {
+        degraded.push({ requested: requestedAttribute, fallback });
+        return;
+      }
+    }
+
+    unsupported.push(requestedAttribute);
+  });
+
+  return { supported, unsupported, degraded };
+};

--- a/src/core/fixtures/index.ts
+++ b/src/core/fixtures/index.ts
@@ -3,5 +3,6 @@ export * from './cache';
 export * from './registry';
 export * from './patch-editor';
 export * from './engine-mapper';
+export * from './capabilities';
 
 export * from './patch-importer';

--- a/src/core/fixtures/patch-importer.ts
+++ b/src/core/fixtures/patch-importer.ts
@@ -1,5 +1,6 @@
 import type { CanonicalFixture, CanonicalFixtureMode, CanonicalShowModel } from '../show/canonical';
 import { validatePatchFixtures } from './patch-editor';
+import { getChannelAttributeId, getFixtureCapabilities } from './capabilities';
 import type {
   FixtureChannelType,
   FixtureProfile,
@@ -420,13 +421,19 @@ const channelTypeToFamily = (channelType: FixtureChannelType): CanonicalShowMode
 };
 
 const toCanonicalFixtureMode = (profile: FixtureProfile, mode: FixtureProfileMode): CanonicalFixtureMode => ({
-  id: mode.id,
+  id: `${profile.profileId}:${mode.id}`,
   name: `${profile.manufacturer} ${profile.model} ${mode.name}`,
   dmxFootprint: mode.channels.length,
+  limitations: {
+    unsupportedAttributes: mode.limitations?.unsupportedAttributes ? [...mode.limitations.unsupportedAttributes] : [],
+    notes: mode.limitations?.notes ? [...mode.limitations.notes] : [],
+  },
   attributes: mode.channels.map((channel, index) => ({
-    attributeId: `${channel.type}.${channel.key}`,
+    attributeId: getChannelAttributeId(channel),
     channels: [index + 1],
     coarseChannel: index + 1,
+    resolutionBits: channel.resolutionBits ?? 8,
+    range: channel.range,
     defaultValue: channel.defaultValue,
   })),
 });
@@ -435,7 +442,7 @@ const toCanonicalFixture = (fixture: PatchFixture): CanonicalFixture => ({
   id: fixture.id,
   name: fixture.name,
   fixtureType: fixture.profileId,
-  modeId: fixture.modeId,
+  modeId: `${fixture.profileId}:${fixture.modeId}`,
   universe: fixture.universe,
   address: fixture.address,
 });
@@ -456,17 +463,18 @@ export const buildShowGraphFromPatch = (
       continue;
     }
 
-    if (!fixtureModes.has(mode.id)) {
-      fixtureModes.set(mode.id, toCanonicalFixtureMode(profile, mode));
+    const fixtureModeId = `${profile.profileId}:${mode.id}`;
+    if (!fixtureModes.has(fixtureModeId)) {
+      fixtureModes.set(fixtureModeId, toCanonicalFixtureMode(profile, mode));
     }
 
-    mode.channels.forEach((channel) => {
-      const attributeId = `${channel.type}.${channel.key}`;
-      if (!attributesCatalog.has(attributeId)) {
-        attributesCatalog.set(attributeId, {
-          id: attributeId,
-          family: channelTypeToFamily(channel.type),
-          label: channel.name,
+    const capabilities = getFixtureCapabilities(profile, mode);
+    Object.values(capabilities.attributes).forEach((attribute) => {
+      if (!attributesCatalog.has(attribute.id)) {
+        attributesCatalog.set(attribute.id, {
+          id: attribute.id,
+          family: channelTypeToFamily(mode.channels[attribute.channels[0] - 1]?.type ?? 'custom'),
+          label: attribute.label,
         });
       }
     });

--- a/src/core/fixtures/types.ts
+++ b/src/core/fixtures/types.ts
@@ -7,22 +7,49 @@ export type FixtureChannelType =
   | 'intensity'
   | 'color'
   | 'position'
+  | 'beam'
+  | 'gobo'
   | 'effect'
   | 'strobe'
   | 'control'
   | 'custom';
 
+export type FixtureChannelResolution = 8 | 16;
+
+export interface FixtureChannelRange {
+  min: number;
+  max: number;
+}
+
 export interface FixtureChannelDefinition {
   key: string;
   name: string;
   type: FixtureChannelType;
+  attribute?: string;
+  aliases?: ReadonlyArray<string>;
+  resolutionBits?: FixtureChannelResolution;
+  fineKey?: string;
+  range?: FixtureChannelRange;
   defaultValue?: FixtureChannelValue;
+}
+
+export interface FixtureMacroDefinition {
+  id: string;
+  name: string;
+  channelKeys: ReadonlyArray<string>;
+}
+
+export interface FixtureModeLimitations {
+  unsupportedAttributes?: ReadonlyArray<string>;
+  notes?: ReadonlyArray<string>;
 }
 
 export interface FixtureProfileMode {
   id: string;
   name: string;
   channels: ReadonlyArray<FixtureChannelDefinition>;
+  macros?: ReadonlyArray<FixtureMacroDefinition>;
+  limitations?: FixtureModeLimitations;
 }
 
 export interface FixtureProfile {

--- a/src/core/show/canonical.ts
+++ b/src/core/show/canonical.ts
@@ -10,11 +10,17 @@ export interface CanonicalFixtureMode {
   id: string;
   name: string;
   dmxFootprint: number;
+  limitations?: {
+    unsupportedAttributes?: string[];
+    notes?: string[];
+  };
   attributes: Array<{
     attributeId: string;
     channels: number[];
     coarseChannel: number;
     fineChannel?: number;
+    resolutionBits?: 8 | 16;
+    range?: { min: number; max: number };
     defaultValue?: number;
   }>;
 }


### PR DESCRIPTION
### Motivation
- Centraliser les définitions des projecteurs (canaux, attributs, macros, plages) pour fournir une source unique utilisée par les modules IA et les exports consoles. 
- Normaliser les noms d’attributs hétérogènes (ex: `ColorMix`, `RGBW`, alias pan/tilt) afin d’éviter la divergence entre profils et traitements downstream. 
- Exposer des métadonnées de capacité (résolution 8/16 bits, plages, coarse/fine, limitations de mode) pour permettre des règles de compatibilité et fallback explicites. 
- Prévenir les collisions et ambiguïtés sur les IDs de mode lors de la conversion patch → show canonique.

### Description
- Ajout de l’API interne `fixture capabilities` dans `src/core/fixtures/capabilities.ts` qui fournit la normalisation d’attributs, la consolidation des capacités par attribut, la détection de dégradations 8→16 bits et le mapping demandé→fourni via `mapRequestedAttributesToCapabilities`.
- Enrichissement du modèle de profil dans `src/core/fixtures/types.ts` avec `attribute`, `aliases`, `resolutionBits`, `range`, `macros` et `limitations` pour capturer les métadonnées nécessaires.
- Intégration de l’API capabilities dans le pipeline de conversion en `src/core/fixtures/patch-importer.ts` en remplaçant la génération brute d’attributs par `getFixtureCapabilities` / `getChannelAttributeId`, et namespacing des mode IDs en `<profileId>:<modeId>` pour éviter les collisions.
- Extension du schéma canonique `src/core/show/canonical.ts` pour transporter les `limitations`, `resolutionBits` et `range` par attribut, export de la nouvelle API via `src/core/fixtures/index.ts`, et mise à jour de la doc `src/core/fixtures/README.md`.

### Testing
- Construction de production exécutée avec `npm run build` et terminée avec succès.
- Suite CI locale lancée avec `npm test` et tous les tests automatiques sont passés (`11 test(s) passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee07f2014c832aa2ce79beffe1f283)