### PR TITLE
Add fixture-aware grouping and palette seeding workflow

### DIFF
--- a/src/core/show/index.ts
+++ b/src/core/show/index.ts
@@ -5,3 +5,5 @@ export * from './persistence';
 export * from './protocol-link';
 
 export * from './canonical';
+
+export * from './preset-seeding';

--- a/src/core/show/preset-seeding.ts
+++ b/src/core/show/preset-seeding.ts
@@ -1,0 +1,295 @@
+import { getFixtureCapabilities } from '../fixtures/capabilities';
+import { FixtureProfileRegistry } from '../fixtures/registry';
+import type {
+  CanonicalAttributeValue,
+  CanonicalFixture,
+  CanonicalGroup,
+  CanonicalPalette,
+  CanonicalShowModel,
+} from './canonical';
+
+type GroupAxis = 'position' | 'fixtureType' | 'scenicRole' | 'zone';
+
+export interface InitialGroupingRule {
+  axis: GroupAxis;
+  enabled: boolean;
+}
+
+export interface GroupProposal extends CanonicalGroup {
+  axis: GroupAxis;
+  source: string;
+}
+
+export interface PaletteProposal extends CanonicalPalette {
+  coverage: 'global' | 'partial';
+  source: string;
+}
+
+export interface SeededPaletteSet {
+  groups: GroupProposal[];
+  palettes: PaletteProposal[];
+}
+
+export interface NamingSuggestion {
+  readableName: string;
+  artisticVariants: string[];
+  cleanedName: string;
+}
+
+export interface NamingAssistant {
+  suggestName: (input: {
+    kind: 'group' | 'palette';
+    baseName: string;
+    fixtureIds: string[];
+    category: string;
+  }) => Promise<NamingSuggestion>;
+}
+
+export interface ValidatableSeedDraft {
+  groups: Array<GroupProposal & { status: 'pending' | 'approved' | 'rejected' }>;
+  palettes: Array<PaletteProposal & { status: 'pending' | 'approved' | 'rejected' }>;
+}
+
+const defaultRules: InitialGroupingRule[] = [
+  { axis: 'position', enabled: true },
+  { axis: 'fixtureType', enabled: true },
+  { axis: 'scenicRole', enabled: true },
+  { axis: 'zone', enabled: true },
+];
+
+const titleCase = (value: string): string =>
+  value
+    .replace(/[_-]+/gu, ' ')
+    .replace(/\s+/gu, ' ')
+    .trim()
+    .split(' ')
+    .filter(Boolean)
+    .map((token) => `${token.charAt(0).toUpperCase()}${token.slice(1).toLowerCase()}`)
+    .join(' ');
+
+const slugify = (value: string): string =>
+  value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/gu, '-')
+    .replace(/(^-|-$)/gu, '');
+
+const extractTagValue = (fixture: CanonicalFixture, prefix: string): string | undefined => {
+  const tag = fixture.tags?.find((entry) => entry.toLowerCase().startsWith(`${prefix.toLowerCase()}:`));
+  return tag?.split(':').slice(1).join(':').trim();
+};
+
+const inferPositionFromName = (fixture: CanonicalFixture): string => {
+  const normalized = `${fixture.name} ${(fixture.tags ?? []).join(' ')}`.toLowerCase();
+  if (/\bfront\b/u.test(normalized)) return 'Front';
+  if (/\bback\b|\bupstage\b/u.test(normalized)) return 'Back';
+  if (/\bleft\b|\bstage-left\b/u.test(normalized)) return 'Left';
+  if (/\bright\b|\bstage-right\b/u.test(normalized)) return 'Right';
+  return `Universe ${fixture.universe}`;
+};
+
+const inferScenicRole = (fixture: CanonicalFixture): string => {
+  const explicit = extractTagValue(fixture, 'role');
+  if (explicit) return titleCase(explicit);
+
+  const normalized = fixture.name.toLowerCase();
+  if (normalized.includes('wash')) return 'Wash';
+  if (normalized.includes('spot')) return 'Spot';
+  if (normalized.includes('beam')) return 'Beam';
+  if (normalized.includes('blinder')) return 'Blinder';
+  return 'Generic';
+};
+
+const inferZone = (fixture: CanonicalFixture): string => {
+  const explicit = extractTagValue(fixture, 'zone');
+  if (explicit) return titleCase(explicit);
+  return `U${fixture.universe}`;
+};
+
+const createAttributeValue = (attributeId: string, value: number | string, scale: CanonicalAttributeValue['scale']): CanonicalAttributeValue => ({
+  attributeId,
+  value,
+  scale,
+});
+
+const inferPaletteValues = (
+  fixture: CanonicalFixture,
+  registry: FixtureProfileRegistry,
+): Array<{ kind: CanonicalPalette['kind']; values: CanonicalAttributeValue[] }> => {
+  const profile = registry.getProfile(fixture.fixtureType);
+  if (!profile) {
+    return [];
+  }
+
+  const modeHint = fixture.modeId.includes(':') ? fixture.modeId.split(':').at(-1) : fixture.modeId;
+  const mode = profile.modes.find((entry) => entry.id === fixture.modeId || entry.id === modeHint);
+  if (!mode) {
+    return [];
+  }
+
+  const capabilities = getFixtureCapabilities(profile, mode);
+  const attributes = Object.keys(capabilities.attributes);
+
+  const palettes: Array<{ kind: CanonicalPalette['kind']; values: CanonicalAttributeValue[] }> = [];
+
+  if (attributes.some((entry) => entry.startsWith('intensity.'))) {
+    palettes.push({ kind: 'intensity', values: [createAttributeValue('intensity.dimmer', 75, 'percent')] });
+  }
+
+  if (attributes.some((entry) => entry.startsWith('color.'))) {
+    palettes.push({ kind: 'color', values: [createAttributeValue('color.rgb', '#FFD18A', 'percent')] });
+  }
+
+  if (attributes.some((entry) => entry.startsWith('position.pan')) || attributes.some((entry) => entry.startsWith('position.tilt'))) {
+    palettes.push({
+      kind: 'position',
+      values: [createAttributeValue('position.pan', 50, 'percent'), createAttributeValue('position.tilt', 50, 'percent')],
+    });
+  }
+
+  if (attributes.some((entry) => entry.startsWith('beam.')) || attributes.some((entry) => entry.includes('strobe'))) {
+    palettes.push({ kind: 'beam', values: [createAttributeValue('beam.zoom', 35, 'percent')] });
+  }
+
+  return palettes;
+};
+
+export const buildInitialGrouping = (
+  fixtures: ReadonlyArray<CanonicalFixture>,
+  rules: ReadonlyArray<InitialGroupingRule> = defaultRules,
+): GroupProposal[] => {
+  const enabledAxes = rules.filter((rule) => rule.enabled).map((rule) => rule.axis);
+  const groupingMap = new Map<string, GroupProposal>();
+
+  const addGroup = (axis: GroupAxis, source: string, fixtureId: string) => {
+    const id = `grp-${slugify(axis)}-${slugify(source)}`;
+    if (!groupingMap.has(id)) {
+      groupingMap.set(id, {
+        id,
+        name: `${titleCase(axis)} · ${titleCase(source)}`,
+        fixtureIds: [],
+        axis,
+        source,
+      });
+    }
+
+    const group = groupingMap.get(id);
+    if (group && !group.fixtureIds.includes(fixtureId)) {
+      group.fixtureIds.push(fixtureId);
+    }
+  };
+
+  fixtures.forEach((fixture) => {
+    enabledAxes.forEach((axis) => {
+      if (axis === 'fixtureType') addGroup(axis, fixture.fixtureType, fixture.id);
+      if (axis === 'position') addGroup(axis, inferPositionFromName(fixture), fixture.id);
+      if (axis === 'scenicRole') addGroup(axis, inferScenicRole(fixture), fixture.id);
+      if (axis === 'zone') addGroup(axis, inferZone(fixture), fixture.id);
+    });
+  });
+
+  return [...groupingMap.values()].sort((a, b) => a.name.localeCompare(b.name));
+};
+
+export const generateBasePalettes = (
+  fixtures: ReadonlyArray<CanonicalFixture>,
+  registry: FixtureProfileRegistry,
+): PaletteProposal[] => {
+  const paletteAccumulator = new Map<string, PaletteProposal>();
+
+  fixtures.forEach((fixture) => {
+    const inferred = inferPaletteValues(fixture, registry);
+    inferred.forEach((entry) => {
+      const id = `pal-${entry.kind}-base`;
+      if (!paletteAccumulator.has(id)) {
+        paletteAccumulator.set(id, {
+          id,
+          name: titleCase(`${entry.kind} base`),
+          kind: entry.kind,
+          values: [],
+          coverage: 'partial',
+          source: 'fixture-capabilities',
+        });
+      }
+
+      const palette = paletteAccumulator.get(id);
+      if (palette) {
+        palette.values.push({ fixtureId: fixture.id, attributes: entry.values });
+      }
+    });
+  });
+
+  return [...paletteAccumulator.values()].map((palette) => ({
+    ...palette,
+    coverage: palette.values.length === fixtures.length ? 'global' : 'partial',
+  }));
+};
+
+export const seedGroupsAndPalettes = (
+  show: Pick<CanonicalShowModel, 'dmx'>,
+  registry: FixtureProfileRegistry,
+  rules?: ReadonlyArray<InitialGroupingRule>,
+): SeededPaletteSet => ({
+  groups: buildInitialGrouping(show.dmx.fixtures, rules),
+  palettes: generateBasePalettes(show.dmx.fixtures, registry),
+});
+
+export const applyNamingAssistant = async (
+  seed: SeededPaletteSet,
+  assistant?: NamingAssistant,
+): Promise<SeededPaletteSet> => {
+  if (!assistant) {
+    return seed;
+  }
+
+  const groups = await Promise.all(
+    seed.groups.map(async (group) => {
+      const suggestion = await assistant.suggestName({
+        kind: 'group',
+        baseName: group.name,
+        fixtureIds: group.fixtureIds,
+        category: group.axis,
+      });
+
+      return {
+        ...group,
+        name: suggestion.cleanedName || suggestion.readableName || group.name,
+      };
+    }),
+  );
+
+  const palettes = await Promise.all(
+    seed.palettes.map(async (palette) => {
+      const fixtureIds = palette.values.map((entry) => entry.fixtureId).filter((id): id is string => Boolean(id));
+      const suggestion = await assistant.suggestName({
+        kind: 'palette',
+        baseName: palette.name,
+        fixtureIds,
+        category: palette.kind,
+      });
+
+      return {
+        ...palette,
+        name: suggestion.cleanedName || suggestion.readableName || palette.name,
+      };
+    }),
+  );
+
+  return { groups, palettes };
+};
+
+export const createValidatableDraft = (seed: SeededPaletteSet): ValidatableSeedDraft => ({
+  groups: seed.groups.map((group) => ({ ...group, status: 'pending' })),
+  palettes: seed.palettes.map((palette) => ({ ...palette, status: 'pending' })),
+});
+
+export const finalizeValidatedDraft = (draft: ValidatableSeedDraft): SeededPaletteSet => {
+  const pendingItems = [...draft.groups, ...draft.palettes].filter((entry) => entry.status !== 'approved');
+  if (pendingItems.length > 0) {
+    throw new Error('Validation manuelle incomplète: approuvez ou retirez chaque proposition avant création finale.');
+  }
+
+  return {
+    groups: draft.groups,
+    palettes: draft.palettes,
+  };
+};

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -1,5 +1,6 @@
 import './unit/lighting-engine.unit.test';
 import './unit/patch-importer.unit.test';
+import './unit/preset-seeding.unit.test';
 import './integration/protocols.integration.test';
 import './e2e/show-workflow.e2e.test';
 import './perf/performance.nonregression.test';

--- a/tests/unit/preset-seeding.unit.test.ts
+++ b/tests/unit/preset-seeding.unit.test.ts
@@ -1,0 +1,119 @@
+import { FixtureProfileRegistry, FIXTURE_PROFILE_FORMAT_VERSION } from '../../src/core/fixtures';
+import {
+  applyNamingAssistant,
+  createValidatableDraft,
+  finalizeValidatedDraft,
+  seedGroupsAndPalettes,
+  type NamingAssistant,
+} from '../../src/core/show/preset-seeding';
+import { assert, test } from '../harness';
+
+const createRegistry = (): FixtureProfileRegistry => {
+  const registry = new FixtureProfileRegistry();
+  registry.importProfiles([
+    {
+      format: FIXTURE_PROFILE_FORMAT_VERSION,
+      manufacturer: 'Acme',
+      model: 'Hybrid',
+      profileId: 'hybrid-wash',
+      modes: [
+        {
+          id: 'std',
+          name: 'Standard',
+          channels: [
+            { key: 'dimmer', name: 'Dimmer', type: 'intensity', attribute: 'dimmer' },
+            { key: 'red', name: 'Red', type: 'color', attribute: 'red' },
+            { key: 'green', name: 'Green', type: 'color', attribute: 'green' },
+            { key: 'blue', name: 'Blue', type: 'color', attribute: 'blue' },
+            { key: 'pan', name: 'Pan', type: 'position', attribute: 'pan' },
+            { key: 'tilt', name: 'Tilt', type: 'position', attribute: 'tilt' },
+            { key: 'zoom', name: 'Zoom', type: 'beam', attribute: 'zoom' },
+          ],
+        },
+      ],
+    },
+  ]);
+  return registry;
+};
+
+test('seedGroupsAndPalettes crée les groupes initiaux et palettes basées capacités fixtures', () => {
+  const registry = createRegistry();
+  const seeded = seedGroupsAndPalettes(
+    {
+      dmx: {
+        fixtures: [
+          {
+            id: 'fx-1',
+            name: 'Front Wash Left',
+            fixtureType: 'hybrid-wash',
+            modeId: 'std',
+            universe: 1,
+            address: 1,
+            tags: ['role:wash', 'zone:frontline'],
+          },
+        ],
+      },
+    },
+    registry,
+  );
+
+  assert.ok(seeded.groups.length >= 4);
+  assert.ok(seeded.groups.some((group) => group.axis === 'position' && group.name.includes('Front')));
+  assert.ok(seeded.groups.some((group) => group.axis === 'scenicRole' && group.name.includes('Wash')));
+  assert.ok(seeded.groups.some((group) => group.axis === 'zone' && group.name.includes('Frontline')));
+  assert.ok(seeded.palettes.some((palette) => palette.kind === 'intensity'));
+  assert.ok(seeded.palettes.some((palette) => palette.kind === 'color'));
+  assert.ok(seeded.palettes.some((palette) => palette.kind === 'position'));
+  assert.ok(seeded.palettes.some((palette) => palette.kind === 'beam'));
+});
+
+test('applyNamingAssistant nettoie les noms proposés par la couche LLM', async () => {
+  const registry = createRegistry();
+  const seeded = seedGroupsAndPalettes(
+    {
+      dmx: {
+        fixtures: [
+          {
+            id: 'fx-1',
+            name: 'Front Wash Left',
+            fixtureType: 'hybrid-wash',
+            modeId: 'std',
+            universe: 1,
+            address: 1,
+          },
+        ],
+      },
+    },
+    registry,
+  );
+
+  const assistant: NamingAssistant = {
+    suggestName: async ({ baseName }) => ({
+      readableName: `Readable ${baseName}`,
+      artisticVariants: [`Alt ${baseName}`],
+      cleanedName: `Clean ${baseName}`,
+    }),
+  };
+
+  const enriched = await applyNamingAssistant(seeded, assistant);
+  assert.ok(enriched.groups.every((group) => group.name.startsWith('Clean ')));
+  assert.ok(enriched.palettes.every((palette) => palette.name.startsWith('Clean ')));
+});
+
+test('finalizeValidatedDraft impose une validation manuelle complète', () => {
+  const draft = createValidatableDraft({ groups: [], palettes: [] });
+  draft.groups.push({
+    id: 'grp-1',
+    name: 'Group 1',
+    fixtureIds: ['fx-1'],
+    axis: 'zone',
+    source: 'U1',
+    status: 'pending',
+  });
+
+  assert.throws(() => finalizeValidatedDraft(draft), /Validation manuelle incomplète/u);
+
+  draft.groups[0].status = 'approved';
+  const finalized = finalizeValidatedDraft(draft);
+  assert.equal(finalized.groups.length, 1);
+});


### PR DESCRIPTION
### Motivation
- Fournir une étape de « seeding » pour accélérer la création initiale de groupes et palettes en se basant sur la position, le type de fixture, le rôle scénique et la zone.
- Générer des palettes de base (intensité, couleur, position, beam) conformes aux capacités réelles des profils de fixtures pour éviter des presets non applicables.
- Permettre une couche optionnelle LLM pour proposer des noms lisibles/artistiques et nettoyer les propositions avant validation.
- Imposer une validation/édition manuelle avant la création finale pour éviter des imports automatiques non vérifiés.

### Description
- Ajout du module `src/core/show/preset-seeding.ts` exposant `buildInitialGrouping`, `generateBasePalettes`, `seedGroupsAndPalettes`, `applyNamingAssistant`, `createValidatableDraft` et `finalizeValidatedDraft` pour gérer le pipeline complet de seed.
- La génération de palettes s’appuie sur `FixtureProfileRegistry` et `getFixtureCapabilities` pour inférer uniquement les palettes compatibles avec les fixtures patchées.
- Intégration d’une interface `NamingAssistant` optionnelle pour déléguer la proposition/normalisation de noms à une couche LLM avant enrichment des objets.
- Export du nouveau workflow via `src/core/show/index.ts` et ajout d’un test unitaire `tests/unit/preset-seeding.unit.test.ts` enregistré dans l’entrée de tests `tests/index.ts`.

### Testing
- Exécution de la suite de tests via `npm test` — tous les tests sont passés (`14 test(s) passed`).
- Test unitaire ajouté: `tests/unit/preset-seeding.unit.test.ts` qui couvre grouping, génération de palettes, assistant de nommage et la validation manuelle; il est inclus dans la suite globale.
- Exécution de `npm run lint` a retourné des erreurs de lint préexistantes dans des fichiers hors périmètre (`src/lib/effects.ts`), ces erreurs ne sont pas liées aux changements et n’ont pas été modifiées par ce PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee09bd2c8c832a9fa10625cd02ec4d)