### PR TITLE
feat(show): add brief planner (brief -> intentions -> cue versions) and feasibility scoring

### DIFF
--- a/src/core/show/brief-planner.ts
+++ b/src/core/show/brief-planner.ts
@@ -1,0 +1,308 @@
+import type { CanonicalCueTiming, CanonicalShowModel } from './canonical';
+
+export type BriefEnergyLevel = 'low' | 'medium' | 'high' | 'peak';
+export type BriefStyle = 'cinematic' | 'club' | 'concert' | 'ambient' | 'theater' | 'hybrid';
+export type BriefVersion = 'safe' | 'balanced' | 'creative';
+
+export interface StructuredBriefConstraint {
+  avoidStrobe?: boolean;
+  avoidBlackout?: boolean;
+  maxIntensityPercent?: number;
+  minTransitionMs?: number;
+  maxCueCount?: number;
+  requiresSmoothTransitions?: boolean;
+}
+
+export interface StructuredBriefMoment {
+  id: string;
+  label: string;
+  atMs: number;
+  energy: BriefEnergyLevel;
+  purpose?: 'intro' | 'build' | 'drop' | 'break' | 'finale' | 'transition';
+  transitionHint?: 'snap' | 'fade' | 'crossfade';
+}
+
+export interface StructuredBrief {
+  style: BriefStyle;
+  energy: {
+    baseline: BriefEnergyLevel;
+    targetPeak: BriefEnergyLevel;
+  };
+  tempo: {
+    bpm: number;
+    syncOnBeat: boolean;
+  };
+  keyMoments: StructuredBriefMoment[];
+  constraints: StructuredBriefConstraint;
+}
+
+export interface LightingIntent {
+  id: string;
+  label: string;
+  atMs: number;
+  priority: 'low' | 'normal' | 'high' | 'critical';
+  energy: BriefEnergyLevel;
+  transition: CanonicalCueTiming;
+  safety: {
+    maxIntensityPercent: number;
+    strobeAllowed: boolean;
+    blackoutAllowed: boolean;
+  };
+}
+
+export interface CueCandidate {
+  id: string;
+  name: string;
+  atMs: number;
+  transition: CanonicalCueTiming;
+  priority: number;
+  safetyPriority: number;
+}
+
+export interface FeasibilityBreakdown {
+  score: number;
+  coverage: {
+    intensity: number;
+    color: number;
+    position: number;
+    beam: number;
+  };
+  limitingFactors: string[];
+}
+
+export interface CueVersionPlan {
+  version: BriefVersion;
+  explanation: string;
+  cues: CueCandidate[];
+}
+
+export interface BriefPlanningResult {
+  brief: StructuredBrief;
+  intentions: LightingIntent[];
+  versions: CueVersionPlan[];
+  feasibility: FeasibilityBreakdown;
+}
+
+const energyRank: Record<BriefEnergyLevel, number> = {
+  low: 1,
+  medium: 2,
+  high: 3,
+  peak: 4,
+};
+
+const energyToIntensity = (energy: BriefEnergyLevel): number => {
+  switch (energy) {
+    case 'low':
+      return 35;
+    case 'medium':
+      return 60;
+    case 'high':
+      return 80;
+    case 'peak':
+      return 95;
+  }
+};
+
+const clamp = (value: number, min: number, max: number): number => Math.max(min, Math.min(max, value));
+
+const normalizeTransition = (
+  atMs: number,
+  energy: BriefEnergyLevel,
+  hint: StructuredBriefMoment['transitionHint'],
+  constraints: StructuredBriefConstraint,
+): CanonicalCueTiming => {
+  const beatMs = 60000 / 128;
+  const minTransitionMs = constraints.minTransitionMs ?? 250;
+  const quick = clamp(Math.round(beatMs), minTransitionMs, 2500);
+  const smooth = clamp(Math.round(beatMs * 2), minTransitionMs, 5000);
+
+  if (hint === 'snap') {
+    return { delayMs: atMs, inMs: minTransitionMs, outMs: quick };
+  }
+
+  if (hint === 'fade' || constraints.requiresSmoothTransitions) {
+    return { delayMs: atMs, inMs: smooth, outMs: smooth, followMs: smooth };
+  }
+
+  const inMs = energyRank[energy] >= 3 ? quick : smooth;
+  return { delayMs: atMs, inMs, outMs: smooth, followMs: quick };
+};
+
+export const buildStructuredBrief = (input: Partial<StructuredBrief> & { style: BriefStyle }): StructuredBrief => {
+  const keyMoments = [...(input.keyMoments ?? [])].sort((a, b) => a.atMs - b.atMs);
+
+  return {
+    style: input.style,
+    energy: {
+      baseline: input.energy?.baseline ?? 'medium',
+      targetPeak: input.energy?.targetPeak ?? 'high',
+    },
+    tempo: {
+      bpm: clamp(input.tempo?.bpm ?? 128, 60, 200),
+      syncOnBeat: input.tempo?.syncOnBeat ?? true,
+    },
+    keyMoments,
+    constraints: {
+      avoidStrobe: input.constraints?.avoidStrobe ?? true,
+      avoidBlackout: input.constraints?.avoidBlackout ?? false,
+      maxIntensityPercent: input.constraints?.maxIntensityPercent ?? 90,
+      minTransitionMs: input.constraints?.minTransitionMs ?? 250,
+      maxCueCount: input.constraints?.maxCueCount,
+      requiresSmoothTransitions: input.constraints?.requiresSmoothTransitions ?? false,
+    },
+  };
+};
+
+export const convertBriefToIntentions = (brief: StructuredBrief): LightingIntent[] =>
+  brief.keyMoments.map((moment, index) => {
+    const transition = normalizeTransition(moment.atMs, moment.energy, moment.transitionHint, brief.constraints);
+    const isCriticalMoment = moment.purpose === 'drop' || moment.purpose === 'finale' || moment.energy === 'peak';
+
+    return {
+      id: `intent-${index + 1}`,
+      label: `${moment.label} (${moment.purpose ?? 'moment'})`,
+      atMs: moment.atMs,
+      priority: isCriticalMoment ? 'critical' : energyRank[moment.energy] >= 3 ? 'high' : 'normal',
+      energy: moment.energy,
+      transition,
+      safety: {
+        maxIntensityPercent: Math.min(
+          energyToIntensity(moment.energy),
+          brief.constraints.maxIntensityPercent ?? 100,
+        ),
+        strobeAllowed: !brief.constraints.avoidStrobe && moment.energy === 'peak',
+        blackoutAllowed: !brief.constraints.avoidBlackout && isCriticalMoment,
+      },
+    };
+  });
+
+const withVersionTuning = (intentions: LightingIntent[], version: BriefVersion): CueCandidate[] => {
+  const tuning = {
+    safe: { intensityFactor: 0.85, extraFollowMs: 400, safetyBias: 3 },
+    balanced: { intensityFactor: 1, extraFollowMs: 250, safetyBias: 2 },
+    creative: { intensityFactor: 1.1, extraFollowMs: 120, safetyBias: 1 },
+  }[version];
+
+  return intentions.map((intent, index) => ({
+    id: `${version}-cue-${index + 1}`,
+    name: `${version.toUpperCase()} · ${intent.label}`,
+    atMs: intent.atMs,
+    transition: {
+      ...intent.transition,
+      followMs: Math.max(0, (intent.transition.followMs ?? 0) + tuning.extraFollowMs),
+      inMs: Math.max(100, Math.round(intent.transition.inMs * (2 - tuning.intensityFactor))),
+    },
+    priority: intent.priority === 'critical' ? 100 : intent.priority === 'high' ? 75 : 50,
+    safetyPriority: intent.safety.strobeAllowed ? tuning.safetyBias : tuning.safetyBias + 2,
+  }));
+};
+
+const capRatio = (supported: number, total: number): number => (total === 0 ? 0 : clamp(supported / total, 0, 1));
+
+export const scoreTechnicalFeasibility = (
+  patch: Pick<CanonicalShowModel, 'dmx' | 'attributesCatalog'>,
+  brief: StructuredBrief,
+): FeasibilityBreakdown => {
+  const fixtureByMode = new Map(patch.dmx.fixtureModes.map((mode) => [mode.id, mode]));
+  const totalFixtures = patch.dmx.fixtures.length;
+  const attributeFamilies = new Map(patch.attributesCatalog.map((attr) => [attr.id, attr.family]));
+
+  let intensityCount = 0;
+  let colorCount = 0;
+  let positionCount = 0;
+  let beamCount = 0;
+
+  for (const fixture of patch.dmx.fixtures) {
+    const mode = fixtureByMode.get(fixture.modeId);
+    if (!mode) {
+      continue;
+    }
+
+    const families = new Set(
+      mode.attributes
+        .map((attr) => attributeFamilies.get(attr.attributeId))
+        .filter((family): family is NonNullable<typeof family> => Boolean(family)),
+    );
+
+    if (families.has('dimmer')) intensityCount += 1;
+    if (families.has('color')) colorCount += 1;
+    if (families.has('position')) positionCount += 1;
+    if (families.has('beam')) beamCount += 1;
+  }
+
+  const coverage = {
+    intensity: capRatio(intensityCount, totalFixtures),
+    color: capRatio(colorCount, totalFixtures),
+    position: capRatio(positionCount, totalFixtures),
+    beam: capRatio(beamCount, totalFixtures),
+  };
+
+  const styleWeight =
+    brief.style === 'club'
+      ? { intensity: 0.3, color: 0.3, position: 0.2, beam: 0.2 }
+      : brief.style === 'theater'
+      ? { intensity: 0.35, color: 0.15, position: 0.35, beam: 0.15 }
+      : { intensity: 0.3, color: 0.25, position: 0.3, beam: 0.15 };
+
+  let score =
+    coverage.intensity * styleWeight.intensity +
+    coverage.color * styleWeight.color +
+    coverage.position * styleWeight.position +
+    coverage.beam * styleWeight.beam;
+
+  if ((brief.constraints.maxIntensityPercent ?? 100) < 70) {
+    score -= 0.08;
+  }
+
+  if (brief.constraints.avoidStrobe) {
+    score += 0.04;
+  }
+
+  const limitingFactors: string[] = [];
+  if (coverage.intensity < 0.5) limitingFactors.push('Faible couverture dimmer (intensity).');
+  if (coverage.color < 0.5) limitingFactors.push('Parc peu équipé en couleur.');
+  if (coverage.position < 0.4) limitingFactors.push('Mouvements limités (pan/tilt).');
+  if (coverage.beam < 0.3) limitingFactors.push('Capacités beam réduites (zoom/iris/gobo).');
+
+  return {
+    score: Math.round(clamp(score, 0, 1) * 100),
+    coverage,
+    limitingFactors,
+  };
+};
+
+export const buildCueVersions = (intentions: LightingIntent[]): CueVersionPlan[] => [
+  {
+    version: 'safe',
+    explanation: 'Priorise des transitions plus longues et des marges de sécurité élevées.',
+    cues: withVersionTuning(intentions, 'safe'),
+  },
+  {
+    version: 'balanced',
+    explanation: 'Compromis entre lisibilité scénique, énergie et robustesse opérationnelle.',
+    cues: withVersionTuning(intentions, 'balanced'),
+  },
+  {
+    version: 'creative',
+    explanation: 'Accentue le contraste des moments clés et réduit les temps de réaction visuels.',
+    cues: withVersionTuning(intentions, 'creative'),
+  },
+];
+
+export const planFromBrief = (
+  input: Partial<StructuredBrief> & { style: BriefStyle },
+  patch: Pick<CanonicalShowModel, 'dmx' | 'attributesCatalog'>,
+): BriefPlanningResult => {
+  const brief = buildStructuredBrief(input);
+  const intentions = convertBriefToIntentions(brief);
+  const maxCueCount = brief.constraints.maxCueCount;
+  const filteredIntentions =
+    typeof maxCueCount === 'number' ? intentions.slice(0, Math.max(1, maxCueCount)) : intentions;
+
+  return {
+    brief,
+    intentions: filteredIntentions,
+    versions: buildCueVersions(filteredIntentions),
+    feasibility: scoreTechnicalFeasibility(patch, brief),
+  };
+};

--- a/src/core/show/index.ts
+++ b/src/core/show/index.ts
@@ -7,3 +7,5 @@ export * from './protocol-link';
 export * from './canonical';
 
 export * from './preset-seeding';
+
+export * from './brief-planner';

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -1,6 +1,7 @@
 import './unit/lighting-engine.unit.test';
 import './unit/patch-importer.unit.test';
 import './unit/preset-seeding.unit.test';
+import './unit/brief-planner.unit.test';
 import './integration/protocols.integration.test';
 import './e2e/show-workflow.e2e.test';
 import './perf/performance.nonregression.test';

--- a/tests/unit/brief-planner.unit.test.ts
+++ b/tests/unit/brief-planner.unit.test.ts
@@ -1,0 +1,132 @@
+import { assert, test } from '../harness';
+import {
+  buildStructuredBrief,
+  convertBriefToIntentions,
+  planFromBrief,
+  scoreTechnicalFeasibility,
+  type StructuredBrief,
+} from '../../src/core/show/brief-planner';
+import type { CanonicalShowModel } from '../../src/core/show/canonical';
+
+const fullPatch: Pick<CanonicalShowModel, 'dmx' | 'attributesCatalog'> = {
+  dmx: {
+    universes: [{ id: 1 }],
+    fixtureModes: [
+      {
+        id: 'wash-mode',
+        name: 'Wash',
+        dmxFootprint: 10,
+        attributes: [
+          { attributeId: 'intensity.dimmer', channels: [1], coarseChannel: 1 },
+          { attributeId: 'color.rgb', channels: [2, 3, 4], coarseChannel: 2 },
+          { attributeId: 'position.pan', channels: [5], coarseChannel: 5 },
+          { attributeId: 'beam.zoom', channels: [6], coarseChannel: 6 },
+        ],
+      },
+    ],
+    fixtures: [
+      {
+        id: 'fx-1',
+        name: 'Wash 1',
+        fixtureType: 'wash',
+        modeId: 'wash-mode',
+        universe: 1,
+        address: 1,
+      },
+      {
+        id: 'fx-2',
+        name: 'Wash 2',
+        fixtureType: 'wash',
+        modeId: 'wash-mode',
+        universe: 1,
+        address: 20,
+      },
+    ],
+  },
+  attributesCatalog: [
+    { id: 'intensity.dimmer', family: 'dimmer', label: 'Dimmer' },
+    { id: 'color.rgb', family: 'color', label: 'Color' },
+    { id: 'position.pan', family: 'position', label: 'Pan' },
+    { id: 'beam.zoom', family: 'beam', label: 'Zoom' },
+  ],
+};
+
+const limitedPatch: Pick<CanonicalShowModel, 'dmx' | 'attributesCatalog'> = {
+  ...fullPatch,
+  dmx: {
+    ...fullPatch.dmx,
+    fixtureModes: [
+      {
+        id: 'dimmer-mode',
+        name: 'Dimmer',
+        dmxFootprint: 1,
+        attributes: [{ attributeId: 'intensity.dimmer', channels: [1], coarseChannel: 1 }],
+      },
+    ],
+    fixtures: [
+      {
+        id: 'fx-d1',
+        name: 'Dimmer 1',
+        fixtureType: 'dimmer',
+        modeId: 'dimmer-mode',
+        universe: 1,
+        address: 1,
+      },
+    ],
+  },
+};
+
+const briefInput: Partial<StructuredBrief> & { style: StructuredBrief['style'] } = {
+  style: 'concert',
+  energy: { baseline: 'low', targetPeak: 'peak' },
+  tempo: { bpm: 132, syncOnBeat: true },
+  constraints: {
+    avoidStrobe: true,
+    maxIntensityPercent: 85,
+    minTransitionMs: 300,
+    maxCueCount: 2,
+  },
+  keyMoments: [
+    { id: 'm1', label: 'Intro', atMs: 0, energy: 'low', purpose: 'intro', transitionHint: 'fade' },
+    { id: 'm2', label: 'Drop', atMs: 30000, energy: 'peak', purpose: 'drop', transitionHint: 'snap' },
+    { id: 'm3', label: 'Finale', atMs: 60000, energy: 'high', purpose: 'finale' },
+  ],
+};
+
+test('buildStructuredBrief complète le format de brief structuré', () => {
+  const brief = buildStructuredBrief({ style: 'club' });
+  assert.equal(brief.style, 'club');
+  assert.equal(brief.tempo.bpm, 128);
+  assert.equal(brief.constraints.avoidStrobe, true);
+});
+
+test('convertBriefToIntentions génère intentions avec transitions + sécurité', () => {
+  const brief = buildStructuredBrief(briefInput);
+  const intentions = convertBriefToIntentions(brief);
+
+  assert.equal(intentions.length, 3);
+  assert.equal(intentions[1].priority, 'critical');
+  assert.equal(intentions[1].safety.strobeAllowed, false);
+  assert.ok((intentions[0].transition.inMs ?? 0) >= 300);
+});
+
+test('planFromBrief produit les versions safe/balanced/creative et limite cue count', () => {
+  const result = planFromBrief(briefInput, fullPatch);
+
+  assert.equal(result.intentions.length, 2);
+  assert.deepEqual(
+    result.versions.map((version) => version.version),
+    ['safe', 'balanced', 'creative'],
+  );
+  assert.ok(result.versions[0].cues[0].safetyPriority > result.versions[2].cues[0].safetyPriority);
+  assert.ok(result.feasibility.score > 0);
+});
+
+test('scoreTechnicalFeasibility baisse quand le patch réel est limité', () => {
+  const brief = buildStructuredBrief(briefInput);
+  const fullScore = scoreTechnicalFeasibility(fullPatch, brief);
+  const limitedScore = scoreTechnicalFeasibility(limitedPatch, brief);
+
+  assert.ok(fullScore.score > limitedScore.score);
+  assert.ok(limitedScore.limitingFactors.length >= 1);
+});


### PR DESCRIPTION
### Motivation
- Provide a deterministic, structured layer to turn a creative lighting brief into executable cue candidates while encoding safety and timing constraints.
- Offer multiple operational variants (safe / balanced / creative) so operators can choose trade-offs between energy/contrast and robustness.
- Surface a technical feasibility score computed from the real fixture patch so the planner can report realistic limits before execution.

### Description
- Add `src/core/show/brief-planner.ts` which defines the structured brief model and implements `buildStructuredBrief`, `convertBriefToIntentions`, `withVersionTuning`/`buildCueVersions`, `planFromBrief`, and `scoreTechnicalFeasibility`.
- Normalization and transition logic compute beat-aligned transitions and incorporate constraints (strobe/blackout, max intensity, min transition times) and per-moment hints (`snap`/`fade`).
- Feasibility scoring maps fixture modes and `attributesCatalog` to capability families (intensity/color/position/beam), computes weighted coverage by `style`, and returns a percent `score` plus `limitingFactors`.
- Export planner API via `src/core/show/index.ts` and add unit tests in `tests/unit/brief-planner.unit.test.ts` with the test runner import updated in `tests/index.ts`.

### Testing
- Ran unit and integration test suite with `npm test`, and all tests passed (18 test(s) passed).
- Built the frontend bundle with `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee0b6ccc98832aa7ba0fb8b8a8b23a)