### PR TITLE
Add V1 console conversion engine with explicit fallback reporting

### DIFF
--- a/src/core/show/console-conversion.ts
+++ b/src/core/show/console-conversion.ts
@@ -1,0 +1,260 @@
+import type { CanonicalAttributeValue, CanonicalCue, CanonicalCuePart, CanonicalPalette, CanonicalShowModel } from './canonical';
+
+export type SupportedConsole = 'grandma3' | 'chamsys' | 'avolites';
+export type MarketRegion = 'eu' | 'uk' | 'us' | 'global';
+
+export interface ConversionJournalEntry {
+  level: 'info' | 'warning';
+  scope: 'attribute' | 'palette' | 'cue' | 'timing' | 'naming' | 'export';
+  sourceId: string;
+  message: string;
+  fallbackApplied?: string;
+}
+
+export interface ConsoleExportArtifact {
+  format: 'json';
+  filename: string;
+  payload: string;
+}
+
+export interface ConsoleConversionResult {
+  targetConsole: SupportedConsole;
+  prioritizedConsoles: SupportedConsole[];
+  exportArtifact: ConsoleExportArtifact;
+  journal: ConversionJournalEntry[];
+  summary: {
+    convertedPalettes: number;
+    convertedCues: number;
+    warnings: number;
+  };
+}
+
+interface ConsoleProfile {
+  timingStepMs: number;
+  naming: {
+    groupPrefix: string;
+    palettePrefix: string;
+    cuePrefix: string;
+  };
+  unsupportedPaletteKinds: CanonicalPalette['kind'][];
+  attributeFallbacks: Record<string, string | null>;
+}
+
+const CONSOLE_PROFILES: Record<SupportedConsole, ConsoleProfile> = {
+  grandma3: {
+    timingStepMs: 1,
+    naming: { groupPrefix: 'Grp', palettePrefix: 'Preset', cuePrefix: 'Cue' },
+    unsupportedPaletteKinds: [],
+    attributeFallbacks: {
+      focusZoom: 'beamZoom',
+    },
+  },
+  chamsys: {
+    timingStepMs: 100,
+    naming: { groupPrefix: 'Group', palettePrefix: 'Palette', cuePrefix: 'Cue' },
+    unsupportedPaletteKinds: ['focus'],
+    attributeFallbacks: {
+      focus: 'beam',
+      focusZoom: 'beamZoom',
+    },
+  },
+  avolites: {
+    timingStepMs: 50,
+    naming: { groupPrefix: 'Grp', palettePrefix: 'Pal', cuePrefix: 'Cue' },
+    unsupportedPaletteKinds: ['focus'],
+    attributeFallbacks: {
+      focus: null,
+      focusZoom: null,
+    },
+  },
+};
+
+export const getPrioritizedConsolesForV1 = (region: MarketRegion): SupportedConsole[] => {
+  switch (region) {
+    case 'eu':
+      return ['grandma3', 'chamsys'];
+    case 'uk':
+      return ['chamsys', 'avolites'];
+    case 'us':
+      return ['grandma3', 'avolites'];
+    default:
+      return ['grandma3', 'chamsys'];
+  }
+};
+
+const withNamingPrefix = (prefix: string, value: string): string => {
+  const trimmed = value.trim();
+  if (trimmed.toLowerCase().startsWith(prefix.toLowerCase())) {
+    return trimmed;
+  }
+  return `${prefix} ${trimmed}`;
+};
+
+const quantizeTiming = (value: number | undefined, stepMs: number): number | undefined => {
+  if (typeof value !== 'number') {
+    return undefined;
+  }
+  if (stepMs <= 1) {
+    return Math.max(0, Math.round(value));
+  }
+  return Math.max(0, Math.round(value / stepMs) * stepMs);
+};
+
+const convertAttributes = (
+  values: CanonicalAttributeValue[],
+  profile: ConsoleProfile,
+  sourceId: string,
+  journal: ConversionJournalEntry[],
+): CanonicalAttributeValue[] => {
+  const converted: CanonicalAttributeValue[] = [];
+
+  for (const attribute of values) {
+    const mapped = profile.attributeFallbacks[attribute.attributeId];
+    if (mapped === null) {
+      journal.push({
+        level: 'warning',
+        scope: 'attribute',
+        sourceId,
+        message: `Attribut ${attribute.attributeId} non supporté sur la console cible.`,
+        fallbackApplied: 'Valeur ignorée (dégradation contrôlée)',
+      });
+      continue;
+    }
+
+    if (typeof mapped === 'string' && mapped !== attribute.attributeId) {
+      journal.push({
+        level: 'warning',
+        scope: 'attribute',
+        sourceId,
+        message: `Attribut ${attribute.attributeId} converti vers ${mapped}.`,
+        fallbackApplied: `Remap attribut vers ${mapped}`,
+      });
+      converted.push({ ...attribute, attributeId: mapped });
+      continue;
+    }
+
+    converted.push(attribute);
+  }
+
+  return converted;
+};
+
+const convertCuePart = (
+  part: CanonicalCuePart,
+  profile: ConsoleProfile,
+  journal: ConversionJournalEntry[],
+): CanonicalCuePart => ({
+  ...part,
+  targets: part.targets.map((target, index) => ({
+    ...target,
+    values: convertAttributes(target.values, profile, `${part.id}:target-${index + 1}`, journal),
+  })),
+});
+
+const convertCue = (cue: CanonicalCue, profile: ConsoleProfile, journal: ConversionJournalEntry[]): CanonicalCue => {
+  const quantized = {
+    inMs: quantizeTiming(cue.timing.inMs, profile.timingStepMs) ?? 0,
+    outMs: quantizeTiming(cue.timing.outMs, profile.timingStepMs),
+    delayMs: quantizeTiming(cue.timing.delayMs, profile.timingStepMs),
+    followMs: quantizeTiming(cue.timing.followMs, profile.timingStepMs),
+  };
+
+  if (
+    quantized.inMs !== cue.timing.inMs ||
+    quantized.outMs !== cue.timing.outMs ||
+    quantized.delayMs !== cue.timing.delayMs ||
+    quantized.followMs !== cue.timing.followMs
+  ) {
+    journal.push({
+      level: 'warning',
+      scope: 'timing',
+      sourceId: cue.id,
+      message: 'Timing quantifié selon la granularité console.',
+      fallbackApplied: `Arrondi au pas ${profile.timingStepMs} ms`,
+    });
+  }
+
+  return {
+    ...cue,
+    name: withNamingPrefix(profile.naming.cuePrefix, cue.name),
+    timing: quantized,
+    parts: cue.parts.map((part) => convertCuePart(part, profile, journal)),
+  };
+};
+
+const convertPalette = (
+  palette: CanonicalPalette,
+  profile: ConsoleProfile,
+  journal: ConversionJournalEntry[],
+): CanonicalPalette | null => {
+  if (profile.unsupportedPaletteKinds.includes(palette.kind)) {
+    journal.push({
+      level: 'warning',
+      scope: 'palette',
+      sourceId: palette.id,
+      message: `Palette ${palette.kind} non supportée sur la console cible.`,
+      fallbackApplied: 'Palette omise, les cues conservent les valeurs directes',
+    });
+    return null;
+  }
+
+  return {
+    ...palette,
+    name: withNamingPrefix(profile.naming.palettePrefix, palette.name),
+    values: palette.values.map((entry, index) => ({
+      ...entry,
+      attributes: convertAttributes(entry.attributes, profile, `${palette.id}:value-${index + 1}`, journal),
+    })),
+  };
+};
+
+export const convertShowToConsole = (
+  show: CanonicalShowModel,
+  options: { region?: MarketRegion; targetConsole?: SupportedConsole } = {},
+): ConsoleConversionResult => {
+  const prioritizedConsoles = getPrioritizedConsolesForV1(options.region ?? 'global');
+  const targetConsole = options.targetConsole ?? prioritizedConsoles[0];
+  const profile = CONSOLE_PROFILES[targetConsole];
+  const journal: ConversionJournalEntry[] = [];
+
+  const convertedGroups = show.groups.map((group) => ({
+    ...group,
+    name: withNamingPrefix(profile.naming.groupPrefix, group.name),
+  }));
+
+  const convertedPalettes = show.palettes
+    .map((palette) => convertPalette(palette, profile, journal))
+    .filter((palette): palette is CanonicalPalette => Boolean(palette));
+
+  const convertedCues = show.cues.map((cue) => convertCue(cue, profile, journal));
+
+  journal.push({
+    level: 'info',
+    scope: 'export',
+    sourceId: show.metadata.showId,
+    message: `Export ${targetConsole} généré avec ${convertedCues.length} cues et ${convertedPalettes.length} palettes.`,
+  });
+
+  const exportPayload: CanonicalShowModel = {
+    ...show,
+    groups: convertedGroups,
+    palettes: convertedPalettes,
+    cues: convertedCues,
+  };
+
+  return {
+    targetConsole,
+    prioritizedConsoles,
+    exportArtifact: {
+      format: 'json',
+      filename: `${show.metadata.showId}-${targetConsole}-import.json`,
+      payload: JSON.stringify(exportPayload, null, 2),
+    },
+    journal,
+    summary: {
+      convertedPalettes: convertedPalettes.length,
+      convertedCues: convertedCues.length,
+      warnings: journal.filter((entry) => entry.level === 'warning').length,
+    },
+  };
+};

--- a/src/core/show/index.ts
+++ b/src/core/show/index.ts
@@ -9,3 +9,4 @@ export * from './canonical';
 export * from './preset-seeding';
 
 export * from './brief-planner';
+export * from './console-conversion';

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -2,6 +2,7 @@ import './unit/lighting-engine.unit.test';
 import './unit/patch-importer.unit.test';
 import './unit/preset-seeding.unit.test';
 import './unit/brief-planner.unit.test';
+import './unit/console-conversion.unit.test';
 import './integration/protocols.integration.test';
 import './e2e/show-workflow.e2e.test';
 import './perf/performance.nonregression.test';

--- a/tests/unit/console-conversion.unit.test.ts
+++ b/tests/unit/console-conversion.unit.test.ts
@@ -1,0 +1,70 @@
+import { convertShowToConsole, getPrioritizedConsolesForV1 } from '../../src/core/show/console-conversion';
+import type { CanonicalShowModel } from '../../src/core/show/canonical';
+import { assert, test } from '../harness';
+
+const buildShow = (): CanonicalShowModel => ({
+  schemaVersion: '1.0.0',
+  metadata: { showId: 'show-v1', title: 'V1 Show' },
+  dmx: {
+    universes: [{ id: 1 }],
+    fixtureModes: [],
+    fixtures: [],
+  },
+  attributesCatalog: [
+    { id: 'dimmer', family: 'dimmer', label: 'Dimmer' },
+    { id: 'focus', family: 'focus', label: 'Focus' },
+  ],
+  groups: [{ id: 'g1', name: 'Face', fixtureIds: ['fx1'] }],
+  palettes: [
+    {
+      id: 'p-focus',
+      name: 'Sharp Focus',
+      kind: 'focus',
+      values: [{ fixtureId: 'fx1', attributes: [{ attributeId: 'focus', value: 50, scale: 'percent' }] }],
+    },
+  ],
+  cues: [
+    {
+      id: 'cue-1',
+      number: '1',
+      name: 'Intro',
+      timing: { inMs: 155, outMs: 255, delayMs: 10 },
+      parts: [
+        {
+          id: 'part-1',
+          targets: [{ fixtureId: 'fx1', values: [{ attributeId: 'focus', value: 30, scale: 'percent' }] }],
+        },
+      ],
+    },
+  ],
+  consoleMappings: [],
+});
+
+test('priorise 2 consoles V1 par région', () => {
+  assert.deepEqual(getPrioritizedConsolesForV1('eu'), ['grandma3', 'chamsys']);
+  assert.deepEqual(getPrioritizedConsolesForV1('uk'), ['chamsys', 'avolites']);
+});
+
+test('applique fallback explicite avec journal pour console sans focus palette', () => {
+  const result = convertShowToConsole(buildShow(), { targetConsole: 'chamsys' });
+
+  assert.equal(result.summary.convertedPalettes, 0);
+  assert.ok(result.summary.warnings >= 2);
+  assert.ok(result.journal.some((entry) => entry.scope === 'palette' && entry.fallbackApplied));
+
+  const parsed = JSON.parse(result.exportArtifact.payload) as CanonicalShowModel;
+  assert.equal(parsed.cues[0].timing.inMs, 200);
+  assert.equal(parsed.cues[0].name, 'Cue Intro');
+});
+
+test('génère un export importable JSON + nommage pour grandMA3', () => {
+  const result = convertShowToConsole(buildShow(), { targetConsole: 'grandma3', region: 'eu' });
+
+  assert.equal(result.exportArtifact.format, 'json');
+  assert.equal(result.exportArtifact.filename, 'show-v1-grandma3-import.json');
+
+  const parsed = JSON.parse(result.exportArtifact.payload) as CanonicalShowModel;
+  assert.equal(parsed.groups[0].name, 'Grp Face');
+  assert.equal(parsed.palettes[0].name, 'Preset Sharp Focus');
+  assert.equal(result.prioritizedConsoles[0], 'grandma3');
+});


### PR DESCRIPTION
### Motivation
- Fournir un moteur de conversion pour V1 qui permet d'exporter le modèle canonique vers consoles cibles prioritaires (grandMA3 / Chamsys / Avolites) en tenant compte du marché et des limitations consoles.
- Gérer les incompatibilités de façon contrôlée en appliquant des fallback explicites (dégradation contrôlée) et en produisant un journal de conversion exploitable pour l'opérateur.
- Générer un artefact d'export importable (JSON) incluant le résultat de la conversion, la priorisation console et un résumé des conversions/warnings.

### Description
- Ajout du module `src/core/show/console-conversion.ts` qui implémente la priorisation par marché (`getPrioritizedConsolesForV1`), profils consoles (`CONSOLE_PROFILES`), remappage d'attributs, quantification du timing, préfixage de noms et journal structuré (`ConversionJournalEntry`).
- La conversion produit un `ConsoleConversionResult` contenant l'artefact JSON exportable, le `journal` des warnings/infos et un `summary` des éléments convertis/warnings.
- Exposition du nouveau module via le barrel `src/core/show/index.ts` et ajout d'un jeu de tests unitaires `tests/unit/console-conversion.unit.test.ts` avec enregistrement dans `tests/index.ts`.
- La logique applique des comportements de fallback explicites (omission de palettes non supportées, remapping d'attributs, arrondi des timings) et enregistre chaque cas dans le journal.

### Testing
- Ajout et exécution des tests unitaires `tests/unit/console-conversion.unit.test.ts` et intégration dans la suite globale via `tests/index.ts`.
- `npm test` exécuté avec succès; tous les tests automatisés passent (`21 test(s) passed`).
- `npm run lint` échoue mais pour des erreurs préexistantes hors de cette modification (notamment `src/lib/effects.ts`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee0c773e84832a9f8c6dc2a2c39577)