### PR TITLE
feat(show): add base-clean template, pre-show cue stack and iteration export

### DIFF
--- a/src/core/show/preset-seeding.ts
+++ b/src/core/show/preset-seeding.ts
@@ -30,6 +30,39 @@ export interface SeededPaletteSet {
   palettes: PaletteProposal[];
 }
 
+export interface PreShowChecklistItem {
+  id: string;
+  label: string;
+  category: 'patch' | 'intensity' | 'position' | 'color';
+  required: boolean;
+}
+
+export interface PreShowTestSequence {
+  id: string;
+  label: string;
+  paletteId?: string;
+  notes: string;
+}
+
+export interface BaseCleanTemplate {
+  groups: GroupProposal[];
+  palettes: PaletteProposal[];
+  testSequences: PreShowTestSequence[];
+  validationChecklist: PreShowChecklistItem[];
+}
+
+export interface CanonicalPreShowCuePlan {
+  cues: CanonicalShowModel['cues'];
+  entryCueId: string | null;
+}
+
+export interface ShowIterationExport {
+  versionId: string;
+  createdAtIso: string;
+  fileName: string;
+  payload: string;
+}
+
 export interface NamingSuggestion {
   readableName: string;
   artisticVariants: string[];
@@ -55,6 +88,14 @@ const defaultRules: InitialGroupingRule[] = [
   { axis: 'fixtureType', enabled: true },
   { axis: 'scenicRole', enabled: true },
   { axis: 'zone', enabled: true },
+];
+
+const PRE_SHOW_CHECKLIST: PreShowChecklistItem[] = [
+  { id: 'patch-universes', label: 'Patch OK (univers, adresses, profils)', category: 'patch', required: true },
+  { id: 'patch-dmx', label: 'Sortie DMX active / sans collision', category: 'patch', required: true },
+  { id: 'intensity-master', label: 'Masters et intensités vérifiés', category: 'intensity', required: true },
+  { id: 'position-home', label: 'Positions Home / focus testés', category: 'position', required: true },
+  { id: 'color-neutral', label: 'Balance couleurs neutres validée', category: 'color', required: true },
 ];
 
 const titleCase = (value: string): string =>
@@ -291,5 +332,107 @@ export const finalizeValidatedDraft = (draft: ValidatableSeedDraft): SeededPalet
   return {
     groups: draft.groups,
     palettes: draft.palettes,
+  };
+};
+
+export const createBaseCleanTemplate = (
+  show: Pick<CanonicalShowModel, 'dmx'>,
+  registry: FixtureProfileRegistry,
+  rules?: ReadonlyArray<InitialGroupingRule>,
+): BaseCleanTemplate => {
+  const seeded = seedGroupsAndPalettes(show, registry, rules);
+  const minimalPalettes = seeded.palettes.filter((palette) =>
+    ['intensity', 'color', 'position', 'focus'].includes(palette.kind),
+  );
+
+  const pickPaletteByKind = (kind: CanonicalPalette['kind']) => minimalPalettes.find((palette) => palette.kind === kind);
+
+  return {
+    groups: seeded.groups,
+    palettes: minimalPalettes,
+    testSequences: [
+      {
+        id: 'seq-focus-check',
+        label: 'Focus check',
+        paletteId: pickPaletteByKind('position')?.id,
+        notes: 'Vérifier ouverture, pointage et symétrie des positions.',
+      },
+      {
+        id: 'seq-balance-check',
+        label: 'Balance check',
+        paletteId: pickPaletteByKind('intensity')?.id,
+        notes: 'Contrôler homogénéité des intensités par zone et type.',
+      },
+      {
+        id: 'seq-base-look',
+        label: 'Base look check',
+        paletteId: pickPaletteByKind('color')?.id,
+        notes: 'Valider look blanc chaud neutre prêt pour répétition.',
+      },
+    ],
+    validationChecklist: PRE_SHOW_CHECKLIST,
+  };
+};
+
+export const generatePreShowCueStack = (
+  template: BaseCleanTemplate,
+): CanonicalPreShowCuePlan => {
+  const buildCue = (id: string, number: string, name: string, paletteKind: CanonicalPalette['kind']): CanonicalShowModel['cues'][number] => {
+    const palette = template.palettes.find((entry) => entry.kind === paletteKind);
+    return {
+      id,
+      number,
+      name,
+      timing: { inMs: 800, outMs: 500 },
+      parts: [
+        {
+          id: `${id}-part-a`,
+          label: 'Base state',
+          targets: [
+            {
+              values: [],
+              paletteRefs: palette ? [palette.id] : [],
+            },
+          ],
+        },
+      ],
+    };
+  };
+
+  const cues = [
+    buildCue('pre-show-focus', '0.1', 'Pre-show · Focus', 'position'),
+    buildCue('pre-show-balance', '0.2', 'Pre-show · Balance', 'intensity'),
+    buildCue('pre-show-base-look', '0.3', 'Pre-show · Base look', 'color'),
+  ];
+
+  return {
+    cues,
+    entryCueId: cues[0]?.id ?? null,
+  };
+};
+
+export const createIterationExport = (
+  payload: unknown,
+  options?: { baseName?: string; versionTag?: string; now?: Date },
+): ShowIterationExport => {
+  const now = options?.now ?? new Date();
+  const stamp = now.toISOString().replace(/[:.]/gu, '-');
+  const versionTag = options?.versionTag?.trim() || 'v1';
+  const baseName = options?.baseName?.trim() || 'show-template';
+  const versionId = `${versionTag}-${stamp}`;
+
+  return {
+    versionId,
+    createdAtIso: now.toISOString(),
+    fileName: `${baseName}.${versionId}.json`,
+    payload: JSON.stringify(
+      {
+        versionId,
+        createdAtIso: now.toISOString(),
+        data: payload,
+      },
+      null,
+      2,
+    ),
   };
 };

--- a/tests/unit/preset-seeding.unit.test.ts
+++ b/tests/unit/preset-seeding.unit.test.ts
@@ -1,8 +1,11 @@
 import { FixtureProfileRegistry, FIXTURE_PROFILE_FORMAT_VERSION } from '../../src/core/fixtures';
 import {
   applyNamingAssistant,
+  createBaseCleanTemplate,
+  createIterationExport,
   createValidatableDraft,
   finalizeValidatedDraft,
+  generatePreShowCueStack,
   seedGroupsAndPalettes,
   type NamingAssistant,
 } from '../../src/core/show/preset-seeding';
@@ -116,4 +119,70 @@ test('finalizeValidatedDraft impose une validation manuelle complète', () => {
   draft.groups[0].status = 'approved';
   const finalized = finalizeValidatedDraft(draft);
   assert.equal(finalized.groups.length, 1);
+});
+
+test('createBaseCleanTemplate prépare groupes, palettes minimales, séquences et checklist', () => {
+  const registry = createRegistry();
+  const template = createBaseCleanTemplate(
+    {
+      dmx: {
+        fixtures: [
+          {
+            id: 'fx-1',
+            name: 'Front Wash Left',
+            fixtureType: 'hybrid-wash',
+            modeId: 'std',
+            universe: 1,
+            address: 1,
+          },
+        ],
+      },
+    },
+    registry,
+  );
+
+  assert.ok(template.groups.length > 0);
+  assert.ok(template.palettes.some((palette) => palette.kind === 'intensity'));
+  assert.ok(template.testSequences.some((sequence) => sequence.id === 'seq-focus-check'));
+  assert.ok(template.validationChecklist.some((item) => item.category === 'patch' && item.required));
+});
+
+test('generatePreShowCueStack génère automatiquement la stack de cues de pré-show', () => {
+  const registry = createRegistry();
+  const template = createBaseCleanTemplate(
+    {
+      dmx: {
+        fixtures: [
+          {
+            id: 'fx-1',
+            name: 'Front Wash Left',
+            fixtureType: 'hybrid-wash',
+            modeId: 'std',
+            universe: 1,
+            address: 1,
+          },
+        ],
+      },
+    },
+    registry,
+  );
+
+  const stack = generatePreShowCueStack(template);
+  assert.equal(stack.cues.length, 3);
+  assert.equal(stack.entryCueId, 'pre-show-focus');
+  assert.deepEqual(
+    stack.cues.map((cue) => cue.name),
+    ['Pre-show · Focus', 'Pre-show · Balance', 'Pre-show · Base look'],
+  );
+});
+
+test("createIterationExport ajoute un versioning exploitable pour itérations rapides", () => {
+  const exported = createIterationExport(
+    { cues: ['pre-show-focus'] },
+    { baseName: 'pre-show', versionTag: 'v2', now: new Date('2026-04-26T12:00:00.000Z') },
+  );
+
+  assert.equal(exported.versionId, 'v2-2026-04-26T12-00-00-000Z');
+  assert.equal(exported.fileName, 'pre-show.v2-2026-04-26T12-00-00-000Z.json');
+  assert.ok(exported.payload.includes('"cues"'));
 });


### PR DESCRIPTION
### Motivation
- Provide a reusable “base propre” template that seeds standard groups and minimal palettes to speed pre-show setup. 
- Automate a minimal pre-show cue stack (focus, balance, base look) so teams have a consistent pre-rehearsal flow.
- Add a simple export + versioning helper for fast iteration snapshots of pre-show plans.

### Description
- Added types and models: `PreShowChecklistItem`, `PreShowTestSequence`, `BaseCleanTemplate`, `CanonicalPreShowCuePlan`, and `ShowIterationExport` in `src/core/show/preset-seeding.ts`.
- Introduced a pre-show checklist constant `PRE_SHOW_CHECKLIST` with patch/intensity/position/color validation items.
- Implemented `createBaseCleanTemplate(show, registry, rules)` to produce groups, minimal palettes, test sequences and the validation checklist.
- Implemented `generatePreShowCueStack(template)` to auto-generate a small set of canonical pre-show cues and `createIterationExport(payload, options)` to produce timestamped, versioned JSON exports.
- Added unit tests in `tests/unit/preset-seeding.unit.test.ts` covering template generation, pre-show cue stack generation and export/versioning behavior.

### Testing
- Ran `npm test -- --filter preset-seeding` and all related tests passed (`24 test(s) passed`).
- Ran `npm run lint` which reported pre-existing lint errors unrelated to these changes (errors in `src/lib/effects.ts`); lint failures are not caused by the new code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee0dc3c884832a9519e5ead93a9597)