### PR TITLE
docs: formaliser la stratégie IA et critères go/no-go DL

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ LightAI-Pro est l'application du futur de conduite lumière de scènes (web + de
 - Chaîne de release: `docs/architecture/release-chain.md`
 - Modèle canonique show (JSON/YAML + mapping consoles): `docs/architecture/show-canonical-model.md`
 
+- Stratégie IA (LLM + heuristiques vs DL custom): `docs/architecture/ai-strategy.md`
+
 
 ### Exemples de show
 - Petit show canonique: `docs/examples/shows/small-show.yaml` (`.json`)

--- a/docs/architecture/ai-strategy.md
+++ b/docs/architecture/ai-strategy.md
@@ -1,0 +1,106 @@
+# Architecture IA — LLM + heuristiques vs Deep Learning custom
+
+## Objectif
+Définir une trajectoire d'architecture IA pragmatique pour LightAI-Pro, en privilégiant la valeur produit mesurable, la sécurité opérationnelle en contexte live et la maîtrise des coûts d'exploitation.
+
+## 1) Comparatif architecture: LLM + heuristiques vs DL custom
+
+### Option A — LLM + heuristiques (recommandé par défaut)
+**Principe**
+- Un LLM sert à l'interprétation (brief opérateur, normalisation sémantique, priorisation).
+- Un moteur heuristique déterministe applique les règles métier critiques (sécurité, compatibilité fixtures, contraintes timing/live).
+- Les sorties sont tracées et explicables via des règles et scores de confiance.
+
+**Forces**
+- Time-to-market rapide (faible cycle d'itération pour améliorer prompts/règles).
+- Risque opérationnel réduit (règles déterministes gardent la main sur les décisions critiques).
+- Coûts initiaux faibles (pas de pipeline d'entraînement lourd au démarrage).
+- Bonne maintenabilité produit (ajout de règles métier sans réentraîner un modèle).
+
+**Limites**
+- Qualité parfois hétérogène sur des cas très spécifiques au domaine lumière.
+- Performance plafonnée si les signaux métier implicites sont trop complexes pour des règles.
+- Dépendance partielle à des modèles tiers pour certaines capacités de compréhension.
+
+### Option B — Deep Learning custom (spécifique domaine)
+**Principe**
+- Modèle entraîné sur des données historiques annotées LightAI-Pro (patch, cues, retouches opérateur, contexte show).
+- Inférence spécialisée pour des tâches ciblées (ranking de suggestions, génération de cues contextualisée, détection d'erreurs complexes).
+
+**Forces**
+- Potentiel de gains supérieurs sur tâches répétitives à forte structure métier.
+- Meilleure adaptation au style opérateur et aux distributions réelles des shows.
+- Moins de dépendance à des comportements génériques de modèles externes.
+
+**Limites**
+- Coût élevé de collecte/annotation/gouvernance des données.
+- Coût infra (entraînement + serving + MLOps) et dette opérationnelle durable.
+- Risques de dérive modèle et besoin d'évaluation continue.
+- Time-to-market plus long avant un ROI clair.
+
+## 2) Critère go / no-go pour lancer un DL custom
+
+Le passage en DL custom est **GO** uniquement si les trois portes ci-dessous sont validées simultanément. Sinon: **NO-GO** et maintien du stack LLM + heuristiques.
+
+### Porte A — Volume et qualité des données annotées
+- Minimum **50 000 exemples exploitables** sur la tâche cible (après nettoyage), avec représentation multi-shows/multi-opérateurs.
+- Taux d'annotation cohérente inter-annotateurs ≥ **0,8** (kappa ou métrique équivalente).
+- Jeu d'évaluation figé, non contaminé, couvrant les scénarios critiques live.
+
+### Porte B — Gain produit mesurable
+- En offline: amélioration relative ≥ **+15 %** sur la métrique primaire métier (ex: taux d'acceptation des cues, réduction retouches).
+- En shadow/canary contrôlé: gain confirmé sur au moins **2 releases** consécutives.
+- Aucune dégradation des garde-fous sécurité (zéro régression sur règles bloquantes).
+
+### Porte C — Coût infra soutenable
+- Coût total mensuel (entraînement amorti + inférence + observabilité) ≤ **30 %** de la valeur opérationnelle générée.
+- Latence p95 compatible usage live (objectif produit inchangé).
+- Équipe capable d'opérer le cycle MLOps (monitoring dérive, rollback modèle, réentraînement).
+
+## 3) Télémétrie produit à implémenter dès maintenant
+
+Objectif: collecter des signaux d'apprentissage utiles **sans** bloquer le produit, tout en conservant traçabilité et gouvernance.
+
+### Événements minimum à tracer
+- `ai_suggestion_shown` (contexte: type de tâche, version modèle/règles, confiance).
+- `ai_suggestion_applied` (application brute).
+- `ai_suggestion_edited` (diff avant/après + ampleur de retouche).
+- `ai_suggestion_rejected` (raison catégorisée).
+- `ai_session_outcome` (temps gagné estimé, satisfaction opérateur, incident éventuel).
+
+### Schéma de données recommandé
+- IDs stables: `project_id`, `show_id`, `cue_id`, `operator_id` pseudonymisé.
+- Contexte technique: `runtime_version`, `ruleset_version`, `model_version`, `feature_flags`.
+- Qualité: `confidence`, `latency_ms`, `validation_state`, `safety_checks_passed`.
+- Feedback explicite: note opérateur, tags de motif de rejet, commentaire court.
+
+### Gouvernance
+- Minimisation des données collectées et pseudonymisation systématique.
+- Rétention différenciée: événements bruts courts, agrégats longs.
+- Journal d'accès et revue périodique des usages d'entraînement.
+
+## 4) Plan d'expérimentation offline avant toute prod DL
+
+Aucun déploiement DL en production sans une phase d'évaluation offline structurée.
+
+### Étapes
+1. **Cadre d'évaluation figé**
+   - Définir tâches, métriques primaires/secondaires, seuils de succès et seuils d'abandon.
+2. **Jeux historiques versionnés**
+   - Split temporel strict (train/validation/test) pour limiter fuite d'information.
+3. **Baselines obligatoires**
+   - Comparer au système courant LLM + heuristiques (baseline principale) et à une baseline naïve.
+4. **Analyse d'erreurs**
+   - Segmenter par type de show, opérateur, complexité patch, conditions live.
+5. **Revue go/no-go**
+   - Appliquer les portes A/B/C ci-dessus; documenter décision signée produit + technique.
+
+### Livrables attendus
+- Rapport d'évaluation offline versionné (métriques + analyses de risques).
+- Recommandation explicite: `NO-GO`, `GO limité (shadow)`, ou `GO canary`.
+- Plan de rollback et critères d'arrêt en cas de dérive post-déploiement.
+
+## Décision architecture recommandée (état actuel)
+- **Court terme**: renforcer l'approche **LLM + heuristiques**.
+- **Moyen terme**: construire la télémétrie et le dataset supervisé.
+- **Long terme**: envisager DL custom uniquement après validation stricte des critères go/no-go.


### PR DESCRIPTION
### Motivation
- Fournir une note d'architecture claire pour orienter la trajectoire IA du produit entre une approche `LLM + heuristiques` et un éventuel `Deep Learning` custom. 
- Définir des critères opérationnels concrets (go/no-go) pour décider du lancement d'un projet DL afin de limiter les risques en production live.
- Mettre en place un plan de télémétrie minimal pour collecter des signaux utiles à un entraînement futur sans bloquer le produit.
- Imposer une phase d'expérimentation offline structurée avant tout déploiement DL en production.

### Description
- Ajout du document `docs/architecture/ai-strategy.md` qui compare les architectures, propose les portes de décision A/B/C pour un `GO/NO-GO`, décrit la télémétrie minimale et détaille un protocole d'évaluation offline.
- Mise à jour de `README.md` pour référencer la nouvelle note depuis la section `Dev`.
- Le document inclut des seuils opérationnels concrets (ex. minimum `50_000` exemples annotés, amélioration attendue `+15%` sur la métrique produit, coût infra cible `≤ 30%` de la valeur opérationnelle) et une liste d'événements de télémétrie à instrumenter (`ai_suggestion_shown`, `ai_suggestion_applied`, `ai_suggestion_edited`, `ai_suggestion_rejected`, `ai_session_outcome`).
- Le plan d'expérimentation offline précise les étapes obligatoires: cadre d'évaluation figé, jeux historiques versionnés (split temporel), baselines (LLM+heuristiques), analyse d'erreurs et livrables attendus (rapport versionné + recommandation GO/NO-GO).

### Testing
- Recherches de cohérence documentaire réalisées avec `rg -n "Copilote IA|LLM|deep learning|télémétrie|expérimentation|offline|heurist" docs README.md` and returned expected hits, confirming integration with existing docs.
- Vérification du diff/preview des fichiers modifiés performed with `git diff -- docs/architecture/ai-strategy.md README.md` and file previews with `nl -ba README.md | sed -n '24,48p'; nl -ba docs/architecture/ai-strategy.md | sed -n '1,260p'`, confirming the new file content and README update.
- Existence of the new file `docs/architecture/ai-strategy.md` validated by listing/preview; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee0ed9af74832a8eda3cd2ac52458b)