### PR TITLE
Add deterministic patch audit pipeline with severity scoring

### DIFF
--- a/src/ai/patch-audit/index.ts
+++ b/src/ai/patch-audit/index.ts
@@ -1,0 +1,221 @@
+import type { PatchFixture } from '../../core/fixtures/types';
+import type { FixtureProfileRegistry } from '../../core/fixtures/registry';
+
+export type PatchAuditStableCode =
+  | 'PA_DMX_ADDRESS_CONFLICT'
+  | 'PA_UNIVERSE_OVERLAP'
+  | 'PA_FIXTURE_MODE_INCONSISTENT'
+  | 'PA_CHANNEL_OUT_OF_RANGE';
+
+export interface PatchAuditFinding {
+  code: PatchAuditStableCode;
+  fixtureId?: string;
+  universe?: number;
+  message: string;
+}
+
+export interface PatchAuditSuggestion {
+  code: 'PA_SUGGEST_REPATCH' | 'PA_SUGGEST_PROFILE_REVIEW';
+  fixtureId?: string;
+  universe?: number;
+  message: string;
+}
+
+export interface PatchAuditResult {
+  issues: PatchAuditFinding[];
+  warnings: PatchAuditFinding[];
+  propositions: PatchAuditSuggestion[];
+  severity: {
+    global: number;
+    byUniverse: Record<number, number>;
+  };
+  durationMs: number;
+}
+
+export type PatchAuditInput =
+  | string
+  | {
+      fixtures?: unknown;
+    }
+  | ReadonlyArray<unknown>;
+
+const MAX_DMX_CHANNEL = 512;
+
+const toNumber = (value: unknown): number | null => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string' && value.trim().length > 0) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+};
+
+const normalizePatchInput = (input: PatchAuditInput): PatchFixture[] => {
+  const parsed =
+    typeof input === 'string'
+      ? (input.trim().startsWith('{') || input.trim().startsWith('[')
+          ? (JSON.parse(input) as unknown)
+          : input)
+      : input;
+
+  if (typeof parsed === 'string') {
+    const rows = parsed.split(/\r?\n/u).map((line) => line.trim()).filter((line) => line.length > 0);
+    if (rows.length < 2) {
+      return [];
+    }
+    const headers = rows[0].split(',').map((cell) => cell.trim().toLowerCase());
+    return rows.slice(1).map((row, index) => {
+      const cells = row.split(',').map((cell) => cell.trim());
+      const get = (key: string): string => cells[headers.indexOf(key)] ?? '';
+      return {
+        id: get('id') || `fixture-${index + 1}`,
+        name: get('name') || get('id') || `fixture-${index + 1}`,
+        profileId: get('profileid'),
+        modeId: get('modeid'),
+        universe: toNumber(get('universe')) ?? 0,
+        address: toNumber(get('address')) ?? 0,
+      };
+    });
+  }
+
+  const rawFixtures = Array.isArray(parsed)
+    ? parsed
+    : parsed && typeof parsed === 'object' && Array.isArray((parsed as { fixtures?: unknown }).fixtures)
+      ? ((parsed as { fixtures: unknown[] }).fixtures as unknown[])
+      : [];
+
+  return rawFixtures
+    .filter((entry): entry is Record<string, unknown> => Boolean(entry && typeof entry === 'object'))
+    .map((entry, index) => ({
+      id: String(entry.id ?? entry.fixtureId ?? `fixture-${index + 1}`),
+      name: String(entry.name ?? entry.label ?? entry.id ?? `fixture-${index + 1}`),
+      profileId: String(entry.profileId ?? entry.fixtureType ?? ''),
+      modeId: String(entry.modeId ?? entry.mode ?? ''),
+      universe: toNumber(entry.universe ?? entry.patchUniverse) ?? 0,
+      address: toNumber(entry.address ?? entry.patchAddress) ?? 0,
+    }));
+};
+
+export const runPatchAudit = (input: PatchAuditInput, registry: FixtureProfileRegistry): PatchAuditResult => {
+  const started = performance.now();
+  const fixtures = normalizePatchInput(input);
+  const issues: PatchAuditFinding[] = [];
+  const warnings: PatchAuditFinding[] = [];
+  const propositions: PatchAuditSuggestion[] = [];
+  const byUniverse = new Map<number, number>();
+
+  const addScore = (universe: number | undefined, points: number): void => {
+    if (typeof universe !== 'number') {
+      return;
+    }
+    byUniverse.set(universe, (byUniverse.get(universe) ?? 0) + points);
+  };
+
+  const occupancy = new Map<string, string>();
+
+  fixtures.forEach((fixture) => {
+    const profile = registry.getProfile(fixture.profileId);
+    const mode = profile?.modes.find((entry) => entry.id === fixture.modeId);
+    const footprint = mode?.channels.length ?? 0;
+
+    if (!mode) {
+      issues.push({
+        code: 'PA_FIXTURE_MODE_INCONSISTENT',
+        fixtureId: fixture.id,
+        universe: fixture.universe,
+        message: `Mode incohérent pour ${fixture.id}: ${fixture.profileId}/${fixture.modeId}.`,
+      });
+      propositions.push({
+        code: 'PA_SUGGEST_PROFILE_REVIEW',
+        fixtureId: fixture.id,
+        universe: fixture.universe,
+        message: `Vérifier le profileId/modeId de ${fixture.id}.`,
+      });
+      addScore(fixture.universe, 40);
+    }
+
+    if (fixture.address < 1 || fixture.address > MAX_DMX_CHANNEL) {
+      issues.push({
+        code: 'PA_CHANNEL_OUT_OF_RANGE',
+        fixtureId: fixture.id,
+        universe: fixture.universe,
+        message: `Adresse DMX hors plage pour ${fixture.id}: ${fixture.address}.`,
+      });
+      addScore(fixture.universe, 50);
+      return;
+    }
+
+    const endAddress = fixture.address + Math.max(footprint - 1, 0);
+    if (endAddress > MAX_DMX_CHANNEL) {
+      issues.push({
+        code: 'PA_CHANNEL_OUT_OF_RANGE',
+        fixtureId: fixture.id,
+        universe: fixture.universe,
+        message: `Footprint dépasse 512 pour ${fixture.id}: ${fixture.address}-${endAddress}.`,
+      });
+      addScore(fixture.universe, 50);
+    }
+
+    for (let channel = fixture.address; channel <= Math.min(endAddress, MAX_DMX_CHANNEL); channel += 1) {
+      const key = `${fixture.universe}:${channel}`;
+      const owner = occupancy.get(key);
+      if (owner) {
+        issues.push({
+          code: 'PA_DMX_ADDRESS_CONFLICT',
+          fixtureId: fixture.id,
+          universe: fixture.universe,
+          message: `Conflit DMX ${fixture.universe}/${channel} entre ${owner} et ${fixture.id}.`,
+        });
+        propositions.push({
+          code: 'PA_SUGGEST_REPATCH',
+          fixtureId: fixture.id,
+          universe: fixture.universe,
+          message: `Repatch recommandé pour ${fixture.id} (univers ${fixture.universe}).`,
+        });
+        addScore(fixture.universe, 80);
+      } else {
+        occupancy.set(key, fixture.id);
+      }
+    }
+  });
+
+  const fixturesByUniverse = new Map<number, PatchFixture[]>();
+  fixtures.forEach((fixture) => {
+    const collection = fixturesByUniverse.get(fixture.universe) ?? [];
+    collection.push(fixture);
+    fixturesByUniverse.set(fixture.universe, collection);
+  });
+
+  fixturesByUniverse.forEach((universeFixtures, universe) => {
+    const sorted = [...universeFixtures].sort((a, b) => a.address - b.address);
+    for (let index = 1; index < sorted.length; index += 1) {
+      const previous = sorted[index - 1];
+      const current = sorted[index];
+      const previousFootprint = registry.getProfile(previous.profileId)?.modes.find((mode) => mode.id === previous.modeId)?.channels.length ?? 1;
+      const previousEnd = previous.address + previousFootprint - 1;
+      if (current.address <= previousEnd && current.id !== previous.id) {
+        warnings.push({
+          code: 'PA_UNIVERSE_OVERLAP',
+          fixtureId: current.id,
+          universe,
+          message: `Chevauchement univers ${universe}: ${previous.id} recouvre ${current.id}.`,
+        });
+        addScore(universe, 20);
+      }
+    }
+  });
+
+  const durationMs = Number((performance.now() - started).toFixed(2));
+  const byUniverseRecord = Object.fromEntries([...byUniverse.entries()].sort((a, b) => a[0] - b[0]));
+  const globalSeverity = Math.min(100, [...byUniverse.values()].reduce((acc, value) => acc + value, 0));
+
+  return {
+    issues,
+    warnings,
+    propositions,
+    severity: { global: globalSeverity, byUniverse: byUniverseRecord },
+    durationMs,
+  };
+};

--- a/src/lib/patchAuditClient.ts
+++ b/src/lib/patchAuditClient.ts
@@ -1,0 +1,24 @@
+import type { FixtureProfileRegistry } from '../core/fixtures/registry';
+import type { PatchAuditInput, PatchAuditResult } from '../ai/patch-audit';
+import { runPatchAudit } from '../ai/patch-audit';
+
+const INTERACTIVE_TARGET_MS = 2000;
+
+export const patchAuditClient = {
+  audit: async (input: PatchAuditInput, registry: FixtureProfileRegistry): Promise<PatchAuditResult> => {
+    const result = runPatchAudit(input, registry);
+    if (result.durationMs > INTERACTIVE_TARGET_MS) {
+      return {
+        ...result,
+        warnings: [
+          ...result.warnings,
+          {
+            code: 'PA_UNIVERSE_OVERLAP',
+            message: `Temps d'audit ${result.durationMs}ms au-dessus de la cible interactive (${INTERACTIVE_TARGET_MS}ms).`,
+          },
+        ],
+      };
+    }
+    return result;
+  },
+};

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -1,5 +1,6 @@
 import './unit/lighting-engine.unit.test';
 import './unit/patch-importer.unit.test';
+import './unit/patch-audit.unit.test';
 import './unit/preset-seeding.unit.test';
 import './unit/brief-planner.unit.test';
 import './unit/console-conversion.unit.test';

--- a/tests/unit/patch-audit.unit.test.ts
+++ b/tests/unit/patch-audit.unit.test.ts
@@ -1,0 +1,61 @@
+import { test, assert } from '../harness';
+import { runPatchAudit } from '../../src/ai/patch-audit';
+import { FixtureProfileRegistry } from '../../src/core/fixtures/registry';
+
+const createRegistry = (): FixtureProfileRegistry => {
+  const registry = new FixtureProfileRegistry();
+  registry.importProfiles([
+    {
+      format: 'lightai.fixture.v1',
+      manufacturer: 'LightAi',
+      model: 'Wash 19',
+      profileId: 'wash-19',
+      modes: [
+        {
+          id: 'mode-10ch',
+          name: '10ch',
+          channels: Array.from({ length: 10 }, (_, index) => ({
+            key: `ch-${index + 1}`,
+            name: `Channel ${index + 1}`,
+            type: 'custom' as const,
+          })),
+        },
+      ],
+    },
+  ]);
+  return registry;
+};
+
+test('Patch audit: génère issues/warnings/propositions avec codes stables', () => {
+  const registry = createRegistry();
+  const result = runPatchAudit(
+    [
+      { id: 'fx-1', name: 'FX1', profileId: 'wash-19', modeId: 'mode-10ch', universe: 1, address: 1 },
+      { id: 'fx-2', name: 'FX2', profileId: 'wash-19', modeId: 'mode-10ch', universe: 1, address: 5 },
+      { id: 'fx-3', name: 'FX3', profileId: 'wash-19', modeId: 'bad-mode', universe: 1, address: 100 },
+      { id: 'fx-4', name: 'FX4', profileId: 'wash-19', modeId: 'mode-10ch', universe: 1, address: 510 },
+    ],
+    registry,
+  );
+
+  assert.ok(result.issues.some((issue) => issue.code === 'PA_DMX_ADDRESS_CONFLICT'));
+  assert.ok(result.issues.some((issue) => issue.code === 'PA_FIXTURE_MODE_INCONSISTENT'));
+  assert.ok(result.issues.some((issue) => issue.code === 'PA_CHANNEL_OUT_OF_RANGE'));
+  assert.ok(result.warnings.some((warning) => warning.code === 'PA_UNIVERSE_OVERLAP'));
+  assert.ok(result.propositions.length > 0);
+  assert.ok(result.severity.global > 0);
+  assert.ok(result.severity.byUniverse[1] > 0);
+});
+
+test('Patch audit: ingestion CSV supportée', () => {
+  const registry = createRegistry();
+  const csv = [
+    'id,name,profileId,modeId,universe,address',
+    'fx-csv-1,CSV One,wash-19,mode-10ch,2,1',
+    'fx-csv-2,CSV Two,wash-19,mode-10ch,2,8',
+  ].join('\n');
+
+  const result = runPatchAudit(csv, registry);
+  assert.equal(result.issues.length > 0, true);
+  assert.ok(result.severity.byUniverse[2] >= 0);
+});

--- a/tests/unit/patch-importer.unit.test.ts
+++ b/tests/unit/patch-importer.unit.test.ts
@@ -5,7 +5,7 @@ import {
   parsePatchSource,
 } from '../../src/core/fixtures/patch-importer';
 import { FixtureProfileRegistry } from '../../src/core/fixtures/registry';
-
+import { patchAuditClient } from '../../src/lib/patchAuditClient';
 const createRegistry = (): FixtureProfileRegistry => {
   const registry = new FixtureProfileRegistry();
   registry.importProfiles([
@@ -101,4 +101,22 @@ test('Sortie Show Graph canonique générée depuis patch valide', () => {
   );
   assert.equal(showGraph.dmx.fixtureModes.length, 1);
   assert.ok(showGraph.attributesCatalog.some((attribute) => attribute.id === 'intensity.dimmer'));
+});
+
+test('Patch importer + audit client: sortie standardisée interactive', async () => {
+  const registry = createRegistry();
+  const parsed = parsePatchSource(
+    [
+      'id,name,profileId,modeId,universe,address',
+      'fx-1,Front Spot,spot-200,mode-8ch,1,1',
+      'fx-2,Back Spot,spot-200,mode-8ch,1,2',
+    ].join('\n'),
+    registry,
+  );
+
+  const audited = await patchAuditClient.audit(parsed.fixtures, registry);
+  assert.ok(Array.isArray(audited.issues));
+  assert.ok(Array.isArray(audited.warnings));
+  assert.ok(Array.isArray(audited.propositions));
+  assert.ok(audited.durationMs < 2000);
 });


### PR DESCRIPTION
### Motivation

- Provide a deterministic, local audit pipeline for imported DMX patches that normalizes CSV/JSON inputs and surfaces actionable, stable diagnostics for UI workflows.
- Detect and prioritise common real-world issues (address conflicts, universe overlaps, invalid fixture modes, and channel/footprint range errors) to assist interactive correction and automation.

### Description

- Added a new audit engine at `src/ai/patch-audit/index.ts` that ingests CSV/JSON, normalizes to `PatchFixture[]`, evaluates deterministic rules, and emits a standardized contract (`issues[]`, `warnings[]`, `propositions[]`) with stable codes such as `PA_DMX_ADDRESS_CONFLICT`, `PA_UNIVERSE_OVERLAP`, `PA_FIXTURE_MODE_INCONSISTENT`, and `PA_CHANNEL_OUT_OF_RANGE`.
- Implemented severity scoring aggregated both globally and per-universe (returned in the `severity` field) to prioritise fixes and guide UI decisions.
- Exposed a simple UI-side client `patchAuditClient` at `src/lib/patchAuditClient.ts` with an interactive response-time target (`2000ms`) that augments results with a warning when the audit exceeds the target.
- Expanded test coverage with `tests/unit/patch-audit.unit.test.ts`, added an integration-style assertion in `tests/unit/patch-importer.unit.test.ts` to verify `parsePatchSource -> patchAuditClient` output shape and latency, and wired the new suite into `tests/index.ts`.

### Testing

- Ran the project test suite with `npm test` (which executes the repository test harness) and observed all tests passing in the final run (`39 test(s) passed`).
- Executed the new unit tests `tests/unit/patch-audit.unit.test.ts` and the updated `tests/unit/patch-importer.unit.test.ts` as part of the full run and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4acef54d0832a978c7b2a85c026d5)