### PR TITLE
Add normalized fixture capability schema, validators, and indexes

### DIFF
--- a/docs/architecture/ai-strategy.md
+++ b/docs/architecture/ai-strategy.md
@@ -104,3 +104,34 @@ Aucun déploiement DL en production sans une phase d'évaluation offline structu
 - **Court terme**: renforcer l'approche **LLM + heuristiques**.
 - **Moyen terme**: construire la télémétrie et le dataset supervisé.
 - **Long terme**: envisager DL custom uniquement après validation stricte des critères go/no-go.
+
+## 5) Contrat du modèle interne de capacités fixtures
+
+Pour aligner l'IA (suggestions palettes/groupes) avec le modèle canonique show (`docs/architecture/show-canonical-model.md`), le moteur fixture expose désormais un schéma interne normalisé `capabilities/channelMap/constraints`.
+
+### Structure contractuelle
+- `capabilities`: dictionnaire par `attributeId` (ex: `color.rgb`, `position.pan`) incluant canaux, résolution et plage.
+- `channelMap`: index strict 1..N des canaux DMX du mode, avec type de famille, attribut résolu, plage et valeur par défaut.
+- `constraints`: espace réservé pour contraintes déclaratives explicites (types/ranges/dépendances de mode), complété par les validateurs.
+
+### Conversion
+- Source: définitions existantes `FixtureProfile` / `FixtureProfileMode` (`lightai.fixture.v1`).
+- Convertisseur: `toCapabilitySchema(profile, mode)`.
+- Garanties: conservation des IDs de profil/mode, attribution canonique stable, résolution/ranges dérivées de la définition brute.
+
+### Validation stricte
+Le validateur `validateCapabilitySchema(schema)` produit un rapport d'incohérence structuré (code, sévérité, message, canal) couvrant:
+- types de canal invalides,
+- plages incohérentes (`min > max`),
+- valeurs par défaut hors plage,
+- dépendances fine/coarse absentes (mode dependency).
+
+### Index de recherche précalculés
+`buildCapabilityIndexes(schema)` expose des index optimisés pour la suggestion IA:
+- `byAttribute`: recherche directe attribut -> canaux.
+- `byFamily`: regroupement rapide par famille (`color`, `position`, `beam`, etc.).
+- `byDmxRange`: segments triés pour heuristiques basées sur plages DMX.
+
+### Compatibilité inter-fixtures
+- La normalisation garantit un contrat identique entre fixtures hétérogènes.
+- Les tests de conversion/validation/indexation servent de garde-fou de compatibilité entre fixtures et modes.

--- a/src/core/fixtures/capabilities.ts
+++ b/src/core/fixtures/capabilities.ts
@@ -64,6 +64,45 @@ export interface FixtureCapabilities {
   compatibility: FixtureCapabilityCompatibility;
 }
 
+export interface CapabilityConstraint {
+  type: 'type' | 'range' | 'modeDependency';
+  message: string;
+}
+
+export interface CapabilityChannelEntry {
+  channel: number;
+  key: string;
+  name: string;
+  type: FixtureChannelDefinition['type'];
+  attributeId: string;
+  resolutionBits: 8 | 16;
+  range: FixtureChannelRange;
+  defaultValue: number;
+}
+
+export interface FixtureCapabilitySchema {
+  profileId: string;
+  modeId: string;
+  capabilities: Record<string, FixtureAttributeCapability>;
+  channelMap: Record<number, CapabilityChannelEntry>;
+  constraints: CapabilityConstraint[];
+}
+
+export interface FixtureCapabilityValidationIssue {
+  code: 'invalidChannelType' | 'invalidRange' | 'invalidDefaultValue' | 'invalidFineDependency';
+  severity: 'error' | 'warning';
+  message: string;
+  modeId: string;
+  profileId: string;
+  channel?: number;
+}
+
+export interface FixtureCapabilityIndexes {
+  byAttribute: Record<string, number[]>;
+  byFamily: Record<string, number[]>;
+  byDmxRange: Array<{ start: number; end: number; attributeId: string }>;
+}
+
 function normalizeAttributeToken(value: string): string {
   return value.replace(/[^a-z0-9]+/giu, '').toLowerCase();
 }
@@ -175,6 +214,134 @@ export const getFixtureCapabilities = (
         notes: mode.limitations?.notes ?? [],
       },
     },
+  };
+};
+
+const allowedChannelTypes = new Set<FixtureChannelDefinition['type']>([
+  'intensity',
+  'color',
+  'position',
+  'beam',
+  'gobo',
+  'effect',
+  'strobe',
+  'control',
+  'custom',
+]);
+
+export const toCapabilitySchema = (profile: FixtureProfile, mode: FixtureProfileMode): FixtureCapabilitySchema => {
+  const capabilities = getFixtureCapabilities(profile, mode);
+  const channelMap: Record<number, CapabilityChannelEntry> = {};
+
+  mode.channels.forEach((channel, index) => {
+    const channelNumber = index + 1;
+    channelMap[channelNumber] = {
+      channel: channelNumber,
+      key: channel.key,
+      name: channel.name,
+      type: channel.type,
+      attributeId: getChannelAttributeId(channel),
+      resolutionBits: channel.resolutionBits ?? 8,
+      range: defaultRangeForChannel(channel),
+      defaultValue: channel.defaultValue ?? 0,
+    };
+  });
+
+  return {
+    profileId: profile.profileId,
+    modeId: mode.id,
+    capabilities: capabilities.attributes,
+    channelMap,
+    constraints: [],
+  };
+};
+
+export const validateCapabilitySchema = (schema: FixtureCapabilitySchema): FixtureCapabilityValidationIssue[] => {
+  const issues: FixtureCapabilityValidationIssue[] = [];
+  const channels = Object.values(schema.channelMap).sort((a, b) => a.channel - b.channel);
+  const channelSet = new Set(channels.map((entry) => entry.channel));
+
+  channels.forEach((entry) => {
+    if (!allowedChannelTypes.has(entry.type)) {
+      issues.push({
+        code: 'invalidChannelType',
+        severity: 'error',
+        message: `Unsupported channel type "${entry.type}" for channel ${entry.channel}.`,
+        modeId: schema.modeId,
+        profileId: schema.profileId,
+        channel: entry.channel,
+      });
+    }
+
+    if (entry.range.min > entry.range.max) {
+      issues.push({
+        code: 'invalidRange',
+        severity: 'error',
+        message: `Invalid range on channel ${entry.channel}: min (${entry.range.min}) > max (${entry.range.max}).`,
+        modeId: schema.modeId,
+        profileId: schema.profileId,
+        channel: entry.channel,
+      });
+    }
+
+    if (entry.defaultValue < entry.range.min || entry.defaultValue > entry.range.max) {
+      issues.push({
+        code: 'invalidDefaultValue',
+        severity: 'error',
+        message: `Default value ${entry.defaultValue} is outside channel ${entry.channel} range [${entry.range.min}, ${entry.range.max}].`,
+        modeId: schema.modeId,
+        profileId: schema.profileId,
+        channel: entry.channel,
+      });
+    }
+
+    if (entry.attributeId.endsWith('Fine')) {
+      const coarseAttribute = entry.attributeId.replace(/Fine$/u, '');
+      const hasCoarse = channels.some((candidate) => candidate.attributeId === coarseAttribute);
+      if (!hasCoarse) {
+        issues.push({
+          code: 'invalidFineDependency',
+          severity: 'warning',
+          message: `Fine channel ${entry.channel} (${entry.attributeId}) has no coarse dependency in mode ${schema.modeId}.`,
+          modeId: schema.modeId,
+          profileId: schema.profileId,
+          channel: entry.channel,
+        });
+      }
+    }
+  });
+
+  const sparseChannels = channels.filter((entry, index) => entry.channel !== index + 1 && !channelSet.has(index + 1));
+  if (sparseChannels.length > 0) {
+    issues.push({
+      code: 'invalidRange',
+      severity: 'warning',
+      message: `Channel map has gaps for mode ${schema.modeId}; found non-contiguous numbering.`,
+      modeId: schema.modeId,
+      profileId: schema.profileId,
+    });
+  }
+
+  return issues;
+};
+
+export const buildCapabilityIndexes = (schema: FixtureCapabilitySchema): FixtureCapabilityIndexes => {
+  const byAttribute = new Map<string, number[]>();
+  const byFamily = new Map<string, number[]>();
+  const byDmxRange: Array<{ start: number; end: number; attributeId: string }> = [];
+
+  Object.values(schema.channelMap).forEach((entry) => {
+    byAttribute.set(entry.attributeId, [...(byAttribute.get(entry.attributeId) ?? []), entry.channel]);
+    byFamily.set(entry.type, [...(byFamily.get(entry.type) ?? []), entry.channel]);
+    byDmxRange.push({ start: entry.range.min, end: entry.range.max, attributeId: entry.attributeId });
+  });
+
+  byDmxRange.sort((left, right) => left.start - right.start || left.end - right.end);
+
+  return {
+    byAttribute: Object.fromEntries(byAttribute.entries()),
+    byFamily: Object.fromEntries(byFamily.entries()),
+    byDmxRange,
   };
 };
 

--- a/tests/unit/capabilities.unit.test.ts
+++ b/tests/unit/capabilities.unit.test.ts
@@ -1,0 +1,57 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildCapabilityIndexes, toCapabilitySchema, validateCapabilitySchema } from '../../src/core/fixtures/capabilities';
+import { FIXTURE_PROFILE_FORMAT_VERSION, type FixtureProfile } from '../../src/core/fixtures/types';
+
+const profile: FixtureProfile = {
+  format: FIXTURE_PROFILE_FORMAT_VERSION,
+  manufacturer: 'LightAi',
+  model: 'Hybrid 200',
+  profileId: 'lightai-hybrid-200',
+  modes: [
+    {
+      id: 'standard',
+      name: 'Standard 8ch',
+      channels: [
+        { key: 'dimmer', name: 'Dimmer', type: 'intensity', defaultValue: 0 },
+        { key: 'red', name: 'Red', type: 'color' },
+        { key: 'green', name: 'Green', type: 'color' },
+        { key: 'blue', name: 'Blue', type: 'color' },
+        { key: 'pan', name: 'Pan', type: 'position', resolutionBits: 8 },
+        { key: 'panFine', name: 'Pan Fine', type: 'position', resolutionBits: 16 },
+      ],
+    },
+  ],
+};
+
+test('conversion vers schema capabilities/channelMap/constraints', () => {
+  const schema = toCapabilitySchema(profile, profile.modes[0]);
+
+  assert.equal(schema.profileId, 'lightai-hybrid-200');
+  assert.equal(schema.modeId, 'standard');
+  assert.equal(schema.channelMap[1].attributeId, 'intensity.dimmer');
+  assert.equal(schema.channelMap[6].attributeId, 'position.panFine');
+  assert.ok(schema.capabilities['color.red']);
+});
+
+test('validation stricte signale incoherences de plage et dependance mode fine/coarse', () => {
+  const schema = toCapabilitySchema(profile, profile.modes[0]);
+  schema.channelMap[2].range = { min: 255, max: 0 };
+  schema.channelMap[3].defaultValue = 500;
+  schema.channelMap[5].attributeId = 'position.tiltFine';
+
+  const issues = validateCapabilitySchema(schema);
+  assert.ok(issues.some((issue) => issue.code === 'invalidRange'));
+  assert.ok(issues.some((issue) => issue.code === 'invalidDefaultValue'));
+  assert.ok(issues.some((issue) => issue.code === 'invalidFineDependency'));
+});
+
+test('indexation attribut/famille/plage DMX compatible fixtures', () => {
+  const schema = toCapabilitySchema(profile, profile.modes[0]);
+  const indexes = buildCapabilityIndexes(schema);
+
+  assert.deepEqual(indexes.byAttribute['color.red'], [2]);
+  assert.deepEqual(indexes.byFamily.color, [2, 3, 4]);
+  assert.equal(indexes.byDmxRange[0].start, 0);
+  assert.ok(indexes.byDmxRange.some((entry) => entry.attributeId === 'position.panFine'));
+});


### PR DESCRIPTION
### Motivation
- Align fixture capability data with the canonical show model so AI heuristics can rely on a stable, console-agnostic contract for suggestions. 
- Surface deterministic validation and incompatibility reports earlier to avoid silent data loss during export/ML suggestions. 
- Precompute searchable indexes to make palette/group suggestion lookups deterministic and fast at runtime. 

### Description
- Introduce a normalized internal schema `FixtureCapabilitySchema` with `capabilities`, `channelMap` and `constraints`, plus related types (`CapabilityConstraint`, `CapabilityChannelEntry`, `FixtureCapabilityValidationIssue`, `FixtureCapabilityIndexes`) in `src/core/fixtures/capabilities.ts`.
- Add a converter `toCapabilitySchema(profile, mode)` that maps existing `FixtureProfile`/`FixtureProfileMode` definitions into the normalized schema while preserving `profileId`/`modeId` and canonical attribute ids.
- Implement strict validator `validateCapabilitySchema(schema)` producing structured issues for invalid channel types, range inconsistencies, default values out of range, and fine/coarse dependencies, and add `buildCapabilityIndexes(schema)` producing `byAttribute`, `byFamily` and sorted `byDmxRange` indexes for fast lookups.
- Add unit tests `tests/unit/capabilities.unit.test.ts` covering conversion, validation scenarios (range/default/fine-coarse dependency), and index generation, and document the model contract in `docs/architecture/ai-strategy.md`.

### Testing
- Added `tests/unit/capabilities.unit.test.ts` and ran the full test suite via `node scripts/run-tests.mjs`, with all tests passing (39 tests passed).
- The new unit tests are exercised as part of the repository test run and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4aec0434c832a9936d1965928c5ba)