### PR TITLE
Add runtime safety monitor before output adapters

### DIFF
--- a/src/components/layout/DiagnosticsPanel.tsx
+++ b/src/components/layout/DiagnosticsPanel.tsx
@@ -9,6 +9,7 @@ export function DiagnosticsPanel() {
   }
 
   const { snapshot, runtimeStatus } = diagnostics;
+  const safetyLogs = snapshot.logs.filter((log) => log.module === 'safety-monitor' || log.tags?.includes('safety')).slice(0, 20);
 
   return (
     <aside className="fixed left-6 top-24 bottom-6 w-[28rem] bg-black/90 border border-yellow-400/40 rounded-xl p-5 overflow-auto z-50">
@@ -39,6 +40,20 @@ export function DiagnosticsPanel() {
           <div>Latency p95: {snapshot.metrics.frameLatencyMsP95} ms</div>
           <div>Dropped frames: {snapshot.metrics.droppedFrames}</div>
           <div>Total frames: {snapshot.metrics.totalFrames}</div>
+        </div>
+
+
+        <div className="bg-gray-900/80 rounded-lg p-3">
+          <div className="font-medium mb-2">AI / Safety Log (live)</div>
+          <div className="space-y-2 max-h-44 overflow-auto pr-1">
+            {safetyLogs.map((log) => (
+              <div key={log.id} className="border border-amber-700/60 rounded-md p-2">
+                <div className="text-xs text-gray-400">{new Date(log.timestamp).toLocaleTimeString()} • {log.level}</div>
+                <div>{log.message}</div>
+              </div>
+            ))}
+            {safetyLogs.length === 0 && <div className="text-gray-400">Aucun événement safety pour le moment.</div>}
+          </div>
         </div>
 
         <div className="bg-gray-900/80 rounded-lg p-3">

--- a/src/core/protocols/types.ts
+++ b/src/core/protocols/types.ts
@@ -46,12 +46,22 @@ export interface SimulatorDriverConfig {
   readonly logFrames?: boolean;
 }
 
+export interface ShowSafetyConfig {
+  readonly profileId?: string;
+  readonly forbidStrobe?: boolean;
+  readonly enforceBlackout?: boolean;
+  readonly maxDeltaPerFrame?: number;
+  readonly forbiddenAttributes?: ReadonlyArray<string>;
+  readonly zoneIntensityMax?: Readonly<Record<string, number>>;
+}
+
 export interface ShowOutputConfig {
   readonly activeDriver: DriverKind;
   readonly artnet?: ArtNetDriverConfig;
   readonly dmx?: DmxDriverConfig;
   readonly osc?: OscDriverConfig;
   readonly simulator?: SimulatorDriverConfig;
+  readonly safety?: ShowSafetyConfig;
 }
 
 export const defaultShowOutputConfig: ShowOutputConfig = {

--- a/src/core/show/protocol-link.ts
+++ b/src/core/show/protocol-link.ts
@@ -1,3 +1,5 @@
+import { observability } from '../../lib/observability';
+import { SafetyMonitor, type SafetyValidationReport } from '../../runtime/safety-monitor';
 import { LightingOutputRouter } from '../protocols/selector';
 import type { ShowOutputConfig } from '../protocols/types';
 import type { ShowState, Universe } from '../lighting-engine/types';
@@ -5,53 +7,43 @@ import type { TimelineSnapshot } from './types';
 
 const parseUniverseKey = (key: string): { universeId: string; channel: number } => {
   const [universeId, channelAsString] = key.split(':');
-  return {
-    universeId,
-    channel: Number(channelAsString),
-  };
+  return { universeId, channel: Number(channelAsString) };
 };
 
 const snapshotToUniverses = (snapshot: TimelineSnapshot): Record<string, Universe> => {
   const universes: Record<string, Universe> = {};
-
   for (const [key, value] of Object.entries(snapshot.values)) {
     const { universeId, channel } = parseUniverseKey(key);
-    const universe = universes[universeId] ?? {
-      id: universeId,
-      name: universeId,
-      size: 512,
-      channels: {},
-    };
-
+    const universe = universes[universeId] ?? { id: universeId, name: universeId, size: 512, channels: {} };
     universe.channels[channel] = Math.max(0, Math.min(255, Math.round(value)));
     universes[universeId] = universe;
   }
-
   return universes;
 };
 
-const snapshotToShowState = (
-  snapshot: TimelineSnapshot,
-  output: ShowOutputConfig,
-): ShowState => ({
-  fixtures: {},
-  scenes: {},
-  cues: {},
-  activeCue: null,
-  currentSceneId: snapshot.activeCueId,
-  tick: 0,
-  output,
-  universes: snapshotToUniverses(snapshot),
-});
+const snapshotToShowState = (snapshot: TimelineSnapshot, output: ShowOutputConfig): ShowState => ({ fixtures: {}, scenes: {}, cues: {}, activeCue: null, currentSceneId: snapshot.activeCueId, tick: 0, output, universes: snapshotToUniverses(snapshot) });
 
 export class ShowProtocolLink {
+  private readonly safetyMonitor = new SafetyMonitor();
   constructor(private readonly router: LightingOutputRouter) {}
 
   async configure(output: ShowOutputConfig): Promise<void> {
+    this.safetyMonitor.setProfile({
+      id: output.safety?.profileId,
+      forbidStrobe: output.safety?.forbidStrobe,
+      enforceBlackout: output.safety?.enforceBlackout,
+      maxDeltaPerFrame: output.safety?.maxDeltaPerFrame,
+      forbiddenAttributes: output.safety?.forbiddenAttributes ? [...output.safety.forbiddenAttributes] : [],
+      zoneLimits: Object.entries(output.safety?.zoneIntensityMax ?? {}).map(([zoneId, maxIntensity]) => ({ zoneId, maxIntensity })),
+    });
     await this.router.setConfiguration(output);
   }
 
-  async sendSnapshot(snapshot: TimelineSnapshot, output: ShowOutputConfig): Promise<void> {
-    await this.router.applyState(snapshotToShowState(snapshot, output));
+  async sendSnapshot(snapshot: TimelineSnapshot, output: ShowOutputConfig): Promise<SafetyValidationReport> {
+    const { safeValues, report } = this.safetyMonitor.validate({ values: snapshot.values, blackout: snapshot.blackout });
+    const safeSnapshot: TimelineSnapshot = { ...snapshot, values: safeValues, blackout: report.level === 'block' ? true : snapshot.blackout };
+    observability.info('safety-monitor', `validation ${report.level}`, { reason: report.reason, rules: report.triggeredRules, cueId: snapshot.activeCueId }, ['ai', 'safety']);
+    await this.router.applyState(snapshotToShowState(safeSnapshot, output));
+    return report;
   }
 }

--- a/src/runtime/safety-monitor/index.ts
+++ b/src/runtime/safety-monitor/index.ts
@@ -1,0 +1,32 @@
+export type SafetyValidationLevel = 'pass' | 'warn' | 'block';
+export interface SafetyRuleHit { rule: string; reason: string }
+export interface SafetyValidationReport { level: SafetyValidationLevel; reason: string; triggeredRules: SafetyRuleHit[] }
+export interface SafetyZoneLimit { zoneId: string; maxIntensity: number; universes?: string[] }
+export interface SafetyProfile { id: string; forbidStrobe: boolean; enforceBlackout: boolean; maxDeltaPerFrame: number; forbiddenAttributes: string[]; zoneLimits: SafetyZoneLimit[] }
+export interface SafetyMonitorInput { values: Record<string, number>; blackout: boolean; attributeByKey?: Record<string, string>; universeZoneMap?: Record<string, string> }
+const clamp = (value: number): number => Math.max(0, Math.min(255, Math.round(value)));
+const DEFAULT_PROFILE: SafetyProfile = { id: 'default', forbidStrobe: false, enforceBlackout: false, maxDeltaPerFrame: 80, forbiddenAttributes: [], zoneLimits: [] };
+export class SafetyMonitor {
+  private profile: SafetyProfile = DEFAULT_PROFILE;
+  private previousValues: Record<string, number> = {};
+  setProfile(profile?: Partial<SafetyProfile>): void { this.profile = { ...DEFAULT_PROFILE, ...profile, forbiddenAttributes: profile?.forbiddenAttributes ?? [], zoneLimits: profile?.zoneLimits ?? [] }; }
+  validate(input: SafetyMonitorInput): { safeValues: Record<string, number>; report: SafetyValidationReport } {
+    const nextValues: Record<string, number> = {}; const hits: SafetyRuleHit[] = [];
+    for (const [key, value] of Object.entries(input.values)) {
+      let next = clamp(value); const previous = this.previousValues[key] ?? 0; const delta = Math.abs(next - previous);
+      if (delta > this.profile.maxDeltaPerFrame) { hits.push({ rule: 'ramp_limit', reason: `${key} delta ${delta} > ${this.profile.maxDeltaPerFrame}` }); next = previous + Math.sign(next - previous) * this.profile.maxDeltaPerFrame; }
+      const attribute = input.attributeByKey?.[key]?.toLowerCase() ?? '';
+      if (this.profile.forbidStrobe && attribute.includes('strobe') && next > 0) { hits.push({ rule: 'forbid_strobe', reason: `${key} blocked strobe attribute` }); next = 0; }
+      if (this.profile.forbiddenAttributes.includes(attribute) && next > 0) { hits.push({ rule: 'forbidden_attribute', reason: `${key} blocked attribute ${attribute}` }); next = 0; }
+      const [universeId] = key.split(':'); const zoneId = input.universeZoneMap?.[universeId] ?? universeId; const zoneRule = this.profile.zoneLimits.find((item) => item.zoneId === zoneId);
+      if (zoneRule && next > zoneRule.maxIntensity) { hits.push({ rule: 'zone_intensity_max', reason: `${key} clamped to zone ${zoneId} max ${zoneRule.maxIntensity}` }); next = zoneRule.maxIntensity; }
+      nextValues[key] = clamp(next);
+    }
+    const blackoutRequested = input.blackout || this.profile.enforceBlackout;
+    const safeValues = blackoutRequested ? Object.fromEntries(Object.keys(nextValues).map((key) => [key, 0])) : nextValues;
+    if (blackoutRequested) hits.push({ rule: 'blackout_rule', reason: 'blackout enforced by show/runtime state' });
+    this.previousValues = { ...safeValues };
+    const level: SafetyValidationLevel = blackoutRequested ? 'block' : hits.length > 0 ? 'warn' : 'pass';
+    return { safeValues, report: { level, reason: hits[0]?.reason ?? 'frame validated', triggeredRules: hits } };
+  }
+}

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -7,6 +7,7 @@ import './unit/console-conversion.unit.test';
 import './unit/live-safety.unit.test';
 import './unit/ai-orchestrator.unit.test';
 import './unit/copilot-workspace.unit.test';
+import './unit/safety-monitor.unit.test';
 import './contracts/ai-orchestrator.contract.test';
 import './integration/protocols.integration.test';
 import './integration/ai-suggestion-events.integration.test';

--- a/tests/unit/safety-monitor.unit.test.ts
+++ b/tests/unit/safety-monitor.unit.test.ts
@@ -1,0 +1,27 @@
+import { assert, test } from '../harness';
+import { SafetyMonitor } from '../../src/runtime/safety-monitor';
+
+test('SafetyMonitor blocks blackout frames', () => {
+  const monitor = new SafetyMonitor();
+  const result = monitor.validate({ values: { '1:1': 255, '1:2': 100 }, blackout: true });
+  assert.equal(result.report.level, 'block');
+  assert.equal(result.safeValues['1:1'], 0);
+  assert.equal(result.safeValues['1:2'], 0);
+});
+
+test('SafetyMonitor clamps burst ramp delta', () => {
+  const monitor = new SafetyMonitor();
+  monitor.setProfile({ maxDeltaPerFrame: 20 });
+  monitor.validate({ values: { '1:1': 0 }, blackout: false });
+  const result = monitor.validate({ values: { '1:1': 255 }, blackout: false });
+  assert.equal(result.report.level, 'warn');
+  assert.equal(result.safeValues['1:1'], 20);
+});
+
+test('SafetyMonitor handles conflicting rules deterministically', () => {
+  const monitor = new SafetyMonitor();
+  monitor.setProfile({ forbidStrobe: true, zoneLimits: [{ zoneId: '1', maxIntensity: 10 }] });
+  const result = monitor.validate({ values: { '1:5': 255 }, blackout: false, attributeByKey: { '1:5': 'strobe' } });
+  assert.equal(result.safeValues['1:5'], 0);
+  assert.ok(result.report.triggeredRules.length >= 1);
+});


### PR DESCRIPTION
### Motivation
- Intercepter 100% des frames/commandes sortantes pour appliquer des règles de sécurité avant les drivers (DMX/Art‑Net/OSC). 
- Fournir des profils sécurité par show (zones, strobe, blackout, ramp limits, attributs interdits) pour éviter incidents live. 
- Rendre les décisions traçables en produisant systématiquement un `SafetyValidationReport` et des logs d’audit immédiats.

### Description
- Ajout d’un composant runtime `src/runtime/safety-monitor/index.ts` qui applique les règles (ramp limit, blocage strobe, blackout, clamps par zone, attributs interdits) et retourne un `SafetyValidationReport` (`pass`/`warn`/`block`).
- Intégration du monitor dans le flux de sortie via `src/core/show/protocol-link.ts` pour valider les `TimelineSnapshot` avant `router.applyState` et émettre une entrée d’observabilité pour chaque validation.
- Extension de la configuration de sortie avec un bloc `safety` dans `src/core/protocols/types.ts` pour stocker le profil sécurité par show (profilId, forbidStrobe, enforceBlackout, maxDeltaPerFrame, forbiddenAttributes, zoneIntensityMax).
- Ajout d’un panneau live `AI / Safety Log` dans `src/components/layout/DiagnosticsPanel.tsx` qui affiche en direct les événements liés à la sécurité pour audit immédiat.
- Ajout de tests unitaires non-régression `tests/unit/safety-monitor.unit.test.ts` couvrant blackout, burst/ramp clamp et conflits de règles.

### Testing
- Added unit tests `tests/unit/safety-monitor.unit.test.ts` exercising blackout enforcement, ramp delta clamping and deterministic conflict resolution (tests committed). 
- Run of the full test runner via `npm test` failed due to the test environment attempting to read `import.meta.env.VITE_APP_VERSION` in Node (existing test harness issue), so the suite could not be executed here. 
- Observability log entries are emitted from `ShowProtocolLink` on each validation and can be inspected in the Diagnostics panel at runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f73d3f8068832aac671d9d9e01ebe7)