### PR TITLE
Add EOS bridge module with copilot-only mode and round-trip tests

### DIFF
--- a/src/integrations/eos-bridge/index.ts
+++ b/src/integrations/eos-bridge/index.ts
@@ -1,0 +1,192 @@
+import type { CanonicalCue, CanonicalPalette, CanonicalShowModel } from '../../core/show/canonical';
+
+export type EosObjectType = 'patch' | 'palette' | 'cue' | 'macro';
+
+export interface EosBridgeWarning {
+  code: 'TIMING_QUANTIZED' | 'UNSUPPORTED_FOLLOW' | 'UNMAPPED_FEATURE';
+  scope: EosObjectType;
+  objectId: string;
+  detail: string;
+}
+
+export interface EosPatchObject {
+  id: string;
+  label: string;
+  address: string;
+  modeId: string;
+}
+
+export interface EosPaletteObject {
+  id: string;
+  category: CanonicalPalette['kind'];
+  label: string;
+  values: CanonicalPalette['values'];
+}
+
+export interface EosCueObject {
+  id: string;
+  number: string;
+  label: string;
+  upTimeTenths: number;
+  downTimeTenths?: number;
+  delayTenths?: number;
+  parts: CanonicalCue['parts'];
+}
+
+export interface EosMacroObject {
+  id: string;
+  label: string;
+  action: string;
+}
+
+export interface EosShowState {
+  patch: EosPatchObject[];
+  palettes: EosPaletteObject[];
+  cues: EosCueObject[];
+  macros: EosMacroObject[];
+}
+
+export interface EosBridgeExportResult {
+  eos: EosShowState;
+  warnings: EosBridgeWarning[];
+  report: {
+    quantizedTimings: number;
+    unmappedFeatures: number;
+  };
+  outputPolicy: {
+    copilotOnly: boolean;
+    localDmxOutputEnabled: boolean;
+    reason: string;
+  };
+}
+
+export interface BridgeOptions {
+  copilotOnly?: boolean;
+}
+
+const quantizeMsToTenths = (ms: number): number => Math.max(0, Math.round(ms / 100));
+const tenthsToMs = (tenths: number | undefined): number | undefined => (tenths === undefined ? undefined : tenths * 100);
+
+export const exportCanonicalShowToEos = (show: CanonicalShowModel, options: BridgeOptions = {}): EosBridgeExportResult => {
+  const warnings: EosBridgeWarning[] = [];
+
+  const patch: EosPatchObject[] = show.dmx.fixtures.map((fixture) => ({
+    id: fixture.id,
+    label: fixture.name,
+    address: `${fixture.universe}/${fixture.address}`,
+    modeId: fixture.modeId,
+  }));
+
+  const palettes: EosPaletteObject[] = show.palettes.map((palette) => ({
+    id: palette.id,
+    category: palette.kind,
+    label: palette.name,
+    values: palette.values,
+  }));
+
+  const cues: EosCueObject[] = show.cues.map((cue) => {
+    const upTimeTenths = quantizeMsToTenths(cue.timing.inMs);
+    const downTimeTenths = quantizeMsToTenths(cue.timing.outMs ?? 0);
+    const delayTenths = quantizeMsToTenths(cue.timing.delayMs ?? 0);
+
+    if (upTimeTenths * 100 !== cue.timing.inMs || (cue.timing.outMs !== undefined && downTimeTenths * 100 !== cue.timing.outMs)) {
+      warnings.push({
+        code: 'TIMING_QUANTIZED',
+        scope: 'cue',
+        objectId: cue.id,
+        detail: 'Timing arrondi à 0.1s pour compatibilité Eos.',
+      });
+    }
+
+    if (cue.timing.followMs !== undefined) {
+      warnings.push({
+        code: 'UNSUPPORTED_FOLLOW',
+        scope: 'cue',
+        objectId: cue.id,
+        detail: 'followMs non mappable vers Eos cue timing natif.',
+      });
+    }
+
+    return {
+      id: cue.id,
+      number: cue.number,
+      label: cue.name,
+      upTimeTenths,
+      downTimeTenths,
+      delayTenths,
+      parts: cue.parts,
+    };
+  });
+
+  const macros: EosMacroObject[] = [
+    {
+      id: 'macro-copilot-sync',
+      label: 'LightAi Sync Pull',
+      action: 'SYNC_CANONICAL_STATE',
+    },
+  ];
+
+  const eosState: EosShowState = { patch, palettes, cues, macros };
+
+  return {
+    eos: eosState,
+    warnings,
+    report: {
+      quantizedTimings: warnings.filter((warning) => warning.code === 'TIMING_QUANTIZED').length,
+      unmappedFeatures: warnings.filter((warning) => warning.code !== 'TIMING_QUANTIZED').length,
+    },
+    outputPolicy: {
+      copilotOnly: Boolean(options.copilotOnly),
+      localDmxOutputEnabled: !options.copilotOnly,
+      reason: options.copilotOnly
+        ? 'Mode copilot-only: aucune sortie DMX locale, pilotage via bridge Eos uniquement.'
+        : 'Sortie locale autorisée en parallèle du bridge Eos.',
+    },
+  };
+};
+
+export const importEosStateToCanonicalSync = (show: CanonicalShowModel, state: EosShowState): CanonicalShowModel => {
+  const cueById = new Map(state.cues.map((cue) => [cue.id, cue]));
+
+  return {
+    ...show,
+    dmx: {
+      ...show.dmx,
+      fixtures: state.patch.map((fixture) => {
+        const [universeToken, addressToken] = fixture.address.split('/');
+        return {
+          id: fixture.id,
+          name: fixture.label,
+          fixtureType: show.dmx.fixtures.find((entry) => entry.id === fixture.id)?.fixtureType ?? 'generic',
+          modeId: fixture.modeId,
+          universe: Number(universeToken),
+          address: Number(addressToken),
+        };
+      }),
+    },
+    palettes: state.palettes.map((palette) => ({
+      id: palette.id,
+      name: palette.label,
+      kind: palette.category,
+      values: palette.values,
+    })),
+    cues: show.cues.map((cue) => {
+      const eosCue = cueById.get(cue.id);
+      if (!eosCue) {
+        return cue;
+      }
+
+      return {
+        ...cue,
+        name: eosCue.label,
+        number: eosCue.number,
+        timing: {
+          inMs: tenthsToMs(eosCue.upTimeTenths) ?? cue.timing.inMs,
+          outMs: tenthsToMs(eosCue.downTimeTenths),
+          delayMs: tenthsToMs(eosCue.delayTenths),
+        },
+        parts: eosCue.parts,
+      };
+    }),
+  };
+};

--- a/tests/fixtures/shows/medium-show.ts
+++ b/tests/fixtures/shows/medium-show.ts
@@ -1,0 +1,31 @@
+import type { CanonicalShowModel } from '../../../src/core/show/canonical';
+
+export const mediumShow: CanonicalShowModel = {
+  schemaVersion: '1.0.0',
+  metadata: { showId: 'medium-show', title: 'Medium Show', bpm: 128 },
+  dmx: {
+    universes: [{ id: 1 }, { id: 2 }],
+    fixtureModes: [
+      { id: 'mode-spot', name: '16ch', dmxFootprint: 16, attributes: [] },
+      { id: 'mode-wash', name: '12ch', dmxFootprint: 12, attributes: [] },
+    ],
+    fixtures: [
+      { id: 'fx-1', name: 'Spot 1', fixtureType: 'spot', modeId: 'mode-spot', universe: 1, address: 1 },
+      { id: 'fx-2', name: 'Spot 2', fixtureType: 'spot', modeId: 'mode-spot', universe: 1, address: 17 },
+      { id: 'fx-3', name: 'Wash 1', fixtureType: 'wash', modeId: 'mode-wash', universe: 2, address: 1 },
+    ],
+  },
+  attributesCatalog: [
+    { id: 'dimmer', family: 'dimmer', label: 'Dimmer' },
+    { id: 'pan', family: 'position', label: 'Pan' },
+  ],
+  groups: [{ id: 'grp-1', name: 'Spots', fixtureIds: ['fx-1', 'fx-2'] }],
+  palettes: [
+    { id: 'pal-1', name: 'Bright', kind: 'intensity', values: [{ groupId: 'grp-1', attributes: [{ attributeId: 'dimmer', value: 100, scale: 'percent' }] }] },
+  ],
+  cues: [
+    { id: 'cue-1', number: '1', name: 'Intro', timing: { inMs: 1200, outMs: 800 }, parts: [{ id: 'p1', targets: [{ groupId: 'grp-1', values: [{ attributeId: 'dimmer', value: 80, scale: 'percent' }] }] }] },
+    { id: 'cue-2', number: '2', name: 'Build', timing: { inMs: 950, delayMs: 75 }, parts: [{ id: 'p2', targets: [{ fixtureId: 'fx-3', values: [{ attributeId: 'pan', value: 10, scale: 'degrees' }] }] }] },
+  ],
+  consoleMappings: [],
+};

--- a/tests/fixtures/shows/small-show.ts
+++ b/tests/fixtures/shows/small-show.ts
@@ -1,0 +1,16 @@
+import type { CanonicalShowModel } from '../../../src/core/show/canonical';
+
+export const smallShow: CanonicalShowModel = {
+  schemaVersion: '1.0.0',
+  metadata: { showId: 'small-show', title: 'Small Show' },
+  dmx: {
+    universes: [{ id: 1 }],
+    fixtureModes: [{ id: 'mode-1', name: '8ch', dmxFootprint: 8, attributes: [] }],
+    fixtures: [{ id: 'fx-1', name: 'Spot 1', fixtureType: 'spot', modeId: 'mode-1', universe: 1, address: 1 }],
+  },
+  attributesCatalog: [{ id: 'dimmer', family: 'dimmer', label: 'Dimmer' }],
+  groups: [{ id: 'grp-1', name: 'All', fixtureIds: ['fx-1'] }],
+  palettes: [{ id: 'pal-1', name: 'Open', kind: 'beam', values: [{ fixtureId: 'fx-1', attributes: [{ attributeId: 'dimmer', value: 100, scale: 'percent' }] }] }],
+  cues: [{ id: 'cue-1', number: '1', name: 'Go', timing: { inMs: 155, outMs: 220, followMs: 300 }, parts: [{ id: 'part-1', targets: [{ fixtureId: 'fx-1', values: [{ attributeId: 'dimmer', value: 100, scale: 'percent' }] }] }] }],
+  consoleMappings: [],
+};

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -4,6 +4,7 @@ import './unit/patch-audit.unit.test';
 import './unit/preset-seeding.unit.test';
 import './unit/brief-planner.unit.test';
 import './unit/console-conversion.unit.test';
+import './unit/eos-bridge.unit.test';
 import './unit/live-safety.unit.test';
 import './unit/ai-orchestrator.unit.test';
 import './unit/copilot-workspace.unit.test';

--- a/tests/unit/eos-bridge.unit.test.ts
+++ b/tests/unit/eos-bridge.unit.test.ts
@@ -1,0 +1,34 @@
+import { exportCanonicalShowToEos, importEosStateToCanonicalSync } from '../../src/integrations/eos-bridge';
+import { mediumShow } from '../fixtures/shows/medium-show';
+import { smallShow } from '../fixtures/shows/small-show';
+import { assert, test } from '../harness';
+
+const verifyRoundTrip = (label: string, show: typeof smallShow | typeof mediumShow) => {
+  test(`round-trip ${label}: export Eos puis réimport + comparaison structurelle`, () => {
+    const exported = exportCanonicalShowToEos(show, { copilotOnly: true });
+
+    assert.equal(exported.outputPolicy.copilotOnly, true);
+    assert.equal(exported.outputPolicy.localDmxOutputEnabled, false);
+    assert.ok(exported.eos.patch.length > 0);
+
+    const reimported = importEosStateToCanonicalSync(show, exported.eos);
+
+    assert.equal(reimported.dmx.fixtures.length, show.dmx.fixtures.length);
+    assert.equal(reimported.palettes.length, show.palettes.length);
+    assert.equal(reimported.cues.length, show.cues.length);
+
+    assert.ok(exported.warnings.length >= 0);
+  });
+};
+
+verifyRoundTrip('small-show', smallShow);
+verifyRoundTrip('medium-show', mediumShow);
+
+test('signale explicitement la perte de granularité timing/features', () => {
+  const exported = exportCanonicalShowToEos(smallShow);
+
+  assert.ok(exported.warnings.some((warning) => warning.code === 'TIMING_QUANTIZED'));
+  assert.ok(exported.warnings.some((warning) => warning.code === 'UNSUPPORTED_FOLLOW'));
+  assert.ok(exported.report.quantizedTimings >= 1);
+  assert.ok(exported.report.unmappedFeatures >= 1);
+});


### PR DESCRIPTION
### Motivation

- Provide an `eos` bridge to translate the canonical show model to EOS-native objects and to sync EOS state back into the canonical model for co-pilot workflows.
- Surface and report losses of granularity (timing quantization and non-mappable features) so operators and the co-pilot can make informed decisions.
- Support a `copilot-only` mode where no local DMX output is enabled and LightAi advises/pilots via the bridge.

### Description

- Add `src/integrations/eos-bridge/index.ts` implementing `exportCanonicalShowToEos` and `importEosStateToCanonicalSync`, EOS object types (patch/palette/cue/macro), timing quantization, explicit warnings, summary report, and an `outputPolicy` with `copilotOnly` behavior.
- Add reference fixtures `tests/fixtures/shows/small-show.ts` and `tests/fixtures/shows/medium-show.ts` to serve as canonical inputs for round-trip tests.
- Add unit tests `tests/unit/eos-bridge.unit.test.ts` that perform export → EOS state → re-import round-trips, validate structural parity (fixtures/palettes/cues), assert warnings for timing quantization and unsupported follow semantics, and verify `copilotOnly` policy behavior.
- Register the new test in `tests/index.ts` so it is included in the project's test bundle.

### Testing

- Attempted to run the test suite via `npm test`, but bundling aborted with a runtime `TypeError` due to `import.meta.env.VITE_APP_VERSION` being `undefined`, which prevented the newly added tests from executing.
- The branch includes automated unit tests that assert round-trip structural comparisons and detection of `TIMING_QUANTIZED` and `UNSUPPORTED_FOLLOW` warnings, and those tests are present in the test bundle though not run in this environment due to the bundling error.
- No failing assertions related to the EOS bridge logic were observed during file creation and local static inspection; CI should run the new unit tests once the environment bundling variable issue is resolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7425ce980832a84d06d207cf6d829)