### PR TITLE
Add reproducible AI evaluation pipeline, release policy, and CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Validate IPC contract governance
         run: node scripts/check-ipc-contract-governance.mjs
 
+      - name: Check AI eval report policy
+        run: npm run ci:ai-report
+
       - name: Lint
         run: npm run lint
 

--- a/artifacts/ai-eval/report-snapshot-2026-05-03__prompt-rules-v1__67c13dc1e43f.json
+++ b/artifacts/ai-eval/report-snapshot-2026-05-03__prompt-rules-v1__67c13dc1e43f.json
@@ -1,0 +1,30 @@
+{
+  "runSignature": "snapshot-2026-05-03__prompt-rules-v1__67c13dc1e43f",
+  "generatedAt": "2026-05-03T13:02:31.829Z",
+  "codeVersion": "67c13dc1e43f22d91419885d47993e53bdb92cf0",
+  "promptRulesVersion": "prompt-rules-v1",
+  "datasetSnapshotId": "snapshot-2026-05-03",
+  "metrics": {
+    "heuristics": {
+      "tp": 1,
+      "tn": 1,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1,
+      "recall": 1,
+      "accuracy": 1,
+      "f1": 1
+    },
+    "llmBaseline": {
+      "tp": 1,
+      "tn": 1,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1,
+      "recall": 1,
+      "accuracy": 1,
+      "f1": 1
+    },
+    "sampleSize": 2
+  }
+}

--- a/artifacts/ai-eval/sample-events.jsonl
+++ b/artifacts/ai-eval/sample-events.jsonl
@@ -1,0 +1,6 @@
+{"event_id":"e1","timestamp":"2026-04-01T09:00:00Z","event_type":"login","actor_id":"u_1","severity":2,"label":0}
+{"event_id":"e2","timestamp":"2026-04-01T09:05:00Z","event_type":"login_failed","actor_id":"u_1","severity":6,"label":1}
+{"event_id":"e3","timestamp":"2026-04-01T10:30:00Z","event_type":"view","actor_id":"u_2","severity":1,"label":0}
+{"event_id":"e4","timestamp":"2026-04-01T10:32:00Z","event_type":"permission_change","actor_id":"u_2","severity":8,"label":1}
+{"event_id":"e5","timestamp":"2026-04-02T12:00:00Z","event_type":"export","actor_id":"u_3","severity":7,"label":1}
+{"event_id":"e6","timestamp":"2026-04-03T12:00:00Z","event_type":"view","actor_id":"u_3","severity":1,"label":0}

--- a/docs/ai/release-policy.md
+++ b/docs/ai/release-policy.md
@@ -1,0 +1,24 @@
+# AI Release Policy
+
+## Objectif
+Empêcher la régression de qualité lors des changements de règles IA / prompts.
+
+## Règle de release (bloquante)
+Aucune règle IA, prompt, ou logique de scoring ne peut être fusionnée sans **rapport d'évaluation minimale validé** dans `artifacts/ai-eval/`.
+
+Un rapport valide doit inclure:
+- `codeVersion` (SHA Git),
+- `promptRulesVersion`,
+- `datasetSnapshotId`,
+- des métriques comparables (`accuracy`, `precision`, `recall`, `f1`) pour baseline heuristique et baseline LLM.
+
+## Évaluation minimale
+- Split temporel déterministe (train/test ordonné par timestamp).
+- Baseline heuristique + baseline LLM.
+- Signature de run unique: `<datasetSnapshotId>__<promptRulesVersion>__<sha12>`.
+
+## Process recommandé
+1. Exécuter `node experiments/run-eval.mjs ...`.
+2. Vérifier les métriques et la cohérence du split.
+3. Versionner le rapport JSON produit dans `artifacts/ai-eval/`.
+4. Ouvrir PR avec mention de la signature de run.

--- a/experiments/README.md
+++ b/experiments/README.md
@@ -1,0 +1,28 @@
+# AI Experiments (reproductibles)
+
+Ce dossier contient des scripts reproductibles pour évaluer les changements IA:
+
+1. `generate-features.mjs`: construit des features à partir d'événements anonymisés.
+2. `temporal-split.mjs`: crée un split temporel train/test déterministe.
+3. `score-baseline.mjs`: exécute un scoring baseline (heuristiques + pseudo-LLM) et calcule des métriques comparables.
+4. `run-eval.mjs`: pipeline bout-en-bout et génération d'un rapport signé dans `artifacts/ai-eval/`.
+
+## Format données attendu
+
+Entrée JSONL (`--input`) avec au minimum:
+
+- `event_id` (string)
+- `timestamp` (ISO-8601)
+- `event_type` (string)
+- `actor_id` (string anonymisé)
+- `severity` (number optionnel)
+- `label` (0/1)
+
+## Exemple rapide
+
+```bash
+node experiments/run-eval.mjs \
+  --input artifacts/ai-eval/sample-events.jsonl \
+  --dataset-snapshot snapshot-2026-05-03 \
+  --prompt-rules-version prompt-rules-v1
+```

--- a/experiments/generate-features.mjs
+++ b/experiments/generate-features.mjs
@@ -1,0 +1,45 @@
+import fs from 'node:fs';
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 2; i < argv.length; i += 1) {
+    if (argv[i].startsWith('--')) args[argv[i].slice(2)] = argv[i + 1];
+  }
+  return args;
+}
+
+const args = parseArgs(process.argv);
+if (!args.input || !args.output) {
+  console.error('Usage: node experiments/generate-features.mjs --input <jsonl> --output <jsonl>');
+  process.exit(1);
+}
+
+const rows = fs.readFileSync(args.input, 'utf8').trim().split('\n').filter(Boolean).map((line) => JSON.parse(line));
+const byActor = new Map();
+
+const features = rows
+  .sort((a, b) => new Date(a.timestamp) - new Date(b.timestamp))
+  .map((event) => {
+    const history = byActor.get(event.actor_id) ?? { count: 0, lastTs: null };
+    const ts = new Date(event.timestamp).getTime();
+    const hour = new Date(event.timestamp).getUTCHours();
+    const deltaMinutes = history.lastTs ? (ts - history.lastTs) / 60000 : null;
+
+    const row = {
+      event_id: event.event_id,
+      timestamp: event.timestamp,
+      actor_id: event.actor_id,
+      event_type: event.event_type,
+      severity: Number(event.severity ?? 0),
+      actor_event_count_before: history.count,
+      minutes_since_last_actor_event: deltaMinutes,
+      hour_utc: hour,
+      label: Number(event.label)
+    };
+
+    byActor.set(event.actor_id, { count: history.count + 1, lastTs: ts });
+    return row;
+  });
+
+fs.writeFileSync(args.output, `${features.map((r) => JSON.stringify(r)).join('\n')}\n`);
+console.log(`Generated ${features.length} feature rows -> ${args.output}`);

--- a/experiments/run-eval.mjs
+++ b/experiments/run-eval.mjs
@@ -1,0 +1,46 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execSync } from 'node:child_process';
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 2; i < argv.length; i += 1) {
+    if (argv[i].startsWith('--')) args[argv[i].slice(2)] = argv[i + 1];
+  }
+  return args;
+}
+
+const args = parseArgs(process.argv);
+if (!args.input || !args.datasetSnapshot || !args.promptRulesVersion) {
+  console.error('Usage: node experiments/run-eval.mjs --input <events.jsonl> --datasetSnapshot <id> --promptRulesVersion <id>');
+  process.exit(1);
+}
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ai-eval-'));
+const features = path.join(tmp, 'features.jsonl');
+const train = path.join(tmp, 'train.jsonl');
+const test = path.join(tmp, 'test.jsonl');
+const baseline = path.join(tmp, 'baseline.json');
+
+execSync(`node experiments/generate-features.mjs --input ${args.input} --output ${features}`, { stdio: 'inherit' });
+execSync(`node experiments/temporal-split.mjs --input ${features} --trainOut ${train} --testOut ${test}`, { stdio: 'inherit' });
+execSync(`node experiments/score-baseline.mjs --input ${test} --output ${baseline}`, { stdio: 'inherit' });
+
+const metrics = JSON.parse(fs.readFileSync(baseline, 'utf8'));
+const codeVersion = execSync('git rev-parse HEAD').toString().trim();
+const runSignature = `${args.datasetSnapshot}__${args.promptRulesVersion}__${codeVersion.slice(0, 12)}`;
+
+const report = {
+  runSignature,
+  generatedAt: new Date().toISOString(),
+  codeVersion,
+  promptRulesVersion: args.promptRulesVersion,
+  datasetSnapshotId: args.datasetSnapshot,
+  metrics
+};
+
+fs.mkdirSync('artifacts/ai-eval', { recursive: true });
+const outPath = `artifacts/ai-eval/report-${runSignature}.json`;
+fs.writeFileSync(outPath, JSON.stringify(report, null, 2));
+console.log(`Wrote signed report: ${outPath}`);

--- a/experiments/score-baseline.mjs
+++ b/experiments/score-baseline.mjs
@@ -1,0 +1,64 @@
+import fs from 'node:fs';
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 2; i < argv.length; i += 1) {
+    if (argv[i].startsWith('--')) args[argv[i].slice(2)] = argv[i + 1];
+  }
+  return args;
+}
+
+function sigmoid(x) {
+  return 1 / (1 + Math.exp(-x));
+}
+
+function predictHeuristic(row) {
+  const bursty = row.minutes_since_last_actor_event !== null && row.minutes_since_last_actor_event < 15;
+  const highSeverity = row.severity >= 7;
+  return bursty || highSeverity ? 1 : 0;
+}
+
+function predictPseudoLlmScore(row) {
+  const risk =
+    0.45 * Number(row.severity) +
+    0.35 * Number(row.actor_event_count_before) +
+    (row.minutes_since_last_actor_event !== null && row.minutes_since_last_actor_event < 20 ? 1.2 : -0.2) +
+    (['login_failed', 'permission_change', 'export'].includes(row.event_type) ? 1 : 0);
+  return sigmoid((risk - 2.8) / 1.5);
+}
+
+function computeMetrics(rows, preds, threshold = 0.5) {
+  let tp = 0; let tn = 0; let fp = 0; let fn = 0;
+  preds.forEach((p, i) => {
+    const y = Number(rows[i].label);
+    const yHat = p >= threshold ? 1 : 0;
+    if (y === 1 && yHat === 1) tp += 1;
+    if (y === 0 && yHat === 0) tn += 1;
+    if (y === 0 && yHat === 1) fp += 1;
+    if (y === 1 && yHat === 0) fn += 1;
+  });
+  const precision = tp + fp === 0 ? 0 : tp / (tp + fp);
+  const recall = tp + fn === 0 ? 0 : tp / (tp + fn);
+  const accuracy = rows.length === 0 ? 0 : (tp + tn) / rows.length;
+  const f1 = precision + recall === 0 ? 0 : (2 * precision * recall) / (precision + recall);
+  return { tp, tn, fp, fn, precision, recall, accuracy, f1 };
+}
+
+const args = parseArgs(process.argv);
+if (!args.input || !args.output) {
+  console.error('Usage: node experiments/score-baseline.mjs --input <test.jsonl> --output <report.json>');
+  process.exit(1);
+}
+
+const rows = fs.readFileSync(args.input, 'utf8').trim().split('\n').filter(Boolean).map((line) => JSON.parse(line));
+const heuristicScores = rows.map((row) => predictHeuristic(row));
+const llmScores = rows.map((row) => predictPseudoLlmScore(row));
+
+const report = {
+  heuristics: computeMetrics(rows, heuristicScores, 0.5),
+  llmBaseline: computeMetrics(rows, llmScores, 0.5),
+  sampleSize: rows.length
+};
+
+fs.writeFileSync(args.output, JSON.stringify(report, null, 2));
+console.log(`Scored ${rows.length} rows -> ${args.output}`);

--- a/experiments/temporal-split.mjs
+++ b/experiments/temporal-split.mjs
@@ -1,0 +1,26 @@
+import fs from 'node:fs';
+
+function parseArgs(argv) {
+  const args = { trainRatio: '0.8' };
+  for (let i = 2; i < argv.length; i += 1) {
+    if (argv[i].startsWith('--')) args[argv[i].slice(2)] = argv[i + 1];
+  }
+  return args;
+}
+
+const args = parseArgs(process.argv);
+if (!args.input || !args.trainOut || !args.testOut) {
+  console.error('Usage: node experiments/temporal-split.mjs --input <features.jsonl> --trainOut <train.jsonl> --testOut <test.jsonl> [--trainRatio 0.8]');
+  process.exit(1);
+}
+
+const trainRatio = Number(args.trainRatio);
+const rows = fs.readFileSync(args.input, 'utf8').trim().split('\n').filter(Boolean).map((line) => JSON.parse(line));
+const sorted = rows.sort((a, b) => new Date(a.timestamp) - new Date(b.timestamp));
+const cut = Math.max(1, Math.floor(sorted.length * trainRatio));
+const train = sorted.slice(0, cut);
+const test = sorted.slice(cut);
+
+fs.writeFileSync(args.trainOut, `${train.map((r) => JSON.stringify(r)).join('\n')}\n`);
+fs.writeFileSync(args.testOut, `${test.map((r) => JSON.stringify(r)).join('\n')}\n`);
+console.log(`Temporal split -> train:${train.length} test:${test.length}`);

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "desktop:build": "npm run build --prefix desktop",
     "test": "node scripts/run-tests.mjs",
     "test:ci": "node scripts/run-tests.mjs",
-    "bench:phase2-exit": "node scripts/run-phase2-exit-bench.mjs"
+    "bench:phase2-exit": "node scripts/run-phase2-exit-bench.mjs",
+    "ai:eval": "node experiments/run-eval.mjs --input artifacts/ai-eval/sample-events.jsonl --datasetSnapshot sample-snapshot-v1 --promptRulesVersion prompt-rules-v1",
+    "ci:ai-report": "node scripts/ci/check-ai-eval-report.mjs"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.39.3",

--- a/scripts/ci/check-ai-eval-report.mjs
+++ b/scripts/ci/check-ai-eval-report.mjs
@@ -1,0 +1,26 @@
+import { execSync } from 'node:child_process';
+
+function sh(cmd) {
+  return execSync(cmd, { encoding: 'utf8' }).trim();
+}
+
+const baseRef = process.env.GITHUB_BASE_REF;
+const base = baseRef ? `origin/${baseRef}` : 'HEAD~1';
+const mergeBase = sh(`git merge-base ${base} HEAD`);
+const changed = sh(`git diff --name-only ${mergeBase} HEAD`).split('\n').filter(Boolean);
+
+const criticalPrefixes = ['src/ai/', 'prompts/', 'rules/', 'jobs/ai-', 'experiments/'];
+const hasCriticalAiChange = changed.some((file) => criticalPrefixes.some((prefix) => file.startsWith(prefix)));
+
+if (!hasCriticalAiChange) {
+  console.log('No critical AI changes detected; skip AI report presence check.');
+  process.exit(0);
+}
+
+const hasEvalReport = changed.some((file) => file.startsWith('artifacts/ai-eval/report-') && file.endsWith('.json'));
+if (!hasEvalReport) {
+  console.error('Critical AI changes detected but no versioned report found in artifacts/ai-eval/report-*.json');
+  process.exit(1);
+}
+
+console.log('Critical AI changes include a versioned evaluation report.');


### PR DESCRIPTION
### Motivation
- Provide a small, reproducible framework to evaluate any change to AI rules/prompts with deterministic data processing and comparable metrics.
- Ensure every critical AI change is accompanied by a versioned, signed evaluation report that links code, prompts/rules, and dataset snapshot.
- Prevent regressions by enforcing a lightweight CI gate that refuses PRs changing AI logic without an evaluation report.

### Description
- Add `experiments/` with four scripts: `generate-features.mjs`, `temporal-split.mjs`, `score-baseline.mjs`, and `run-eval.mjs`, plus `experiments/README.md` describing inputs and usage. 
- Add an example dataset `artifacts/ai-eval/sample-events.jsonl` and a versioned signed report `artifacts/ai-eval/report-*.json` produced by the pipeline. 
- Add AI release policy documentation at `docs/ai/release-policy.md` requiring a minimal validated evaluation report for changes to rules/prompts/scoring. 
- Add CI check script `scripts/ci/check-ai-eval-report.mjs`, wire it into the GitHub Actions workflow, and add `ai:eval` and `ci:ai-report` npm scripts in `package.json`.

### Testing
- Ran the end-to-end pipeline with `node experiments/run-eval.mjs --input artifacts/ai-eval/sample-events.jsonl --datasetSnapshot snapshot-2026-05-03 --promptRulesVersion prompt-rules-v1` and it completed successfully, producing a signed JSON report in `artifacts/ai-eval/`.
- Ran the CI gate check with `node scripts/ci/check-ai-eval-report.mjs` and it exited successfully on the current tree, reporting no critical AI changes.
- The new CI step was added to `.github/workflows/ci.yml` to execute `npm run ci:ai-report` as part of validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f746ece280832a89440ed508bcc243)