### PR TITLE
Fix Windows signing hash configuration

### DIFF
--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -48,8 +48,9 @@ win:
     - target: nsis
       arch:
         - x64
-  signingHashAlgorithms:
-    - sha256
+  signtoolOptions:
+    signingHashAlgorithms:
+      - sha256
 
 nsis:
   oneClick: false


### PR DESCRIPTION
### Motivation
- Ensure the Windows signing configuration is accepted by `electron-builder` by moving `signingHashAlgorithms` under `signtoolOptions` so the signtool settings are applied correctly.

### Description
- Update `desktop/electron-builder.yml` to replace the `win` block that had `signingHashAlgorithms` at the top level with a `signtoolOptions` block containing `signingHashAlgorithms`, leaving the NSIS `x64` target unchanged.

### Testing
- Successfully parsed `desktop/electron-builder.yml` with `js-yaml` via `node` and verified the new `signtoolOptions`/`signingHashAlgorithms` keys with `rg`, both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04a6e4f268832a9b86fee67f1be161)