### PR TITLE
Build desktop app from compiled JavaScript

### DIFF
--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -5,13 +5,10 @@ directories:
   buildResources: ./build
 files:
   - ../dist/**
-  - ./main.ts
-  - ./preload.ts
-  - ./ipc/**
-  - ./native/**
+  - ./dist/**
   - ./security/**
 extraMetadata:
-  main: main.ts
+  main: dist/main.js
 artifactName: "${productName}-${version}-${os}-${arch}-${channel}.${ext}"
 buildDependenciesFromSource: false
 asar: true

--- a/desktop/ipc/handlers.ts
+++ b/desktop/ipc/handlers.ts
@@ -5,9 +5,9 @@ import {
   assertVaultSecretKeyRequest,
   assertVaultSecretRequest,
   ipcChannels
-} from './contracts';
-import type { HardwareRuntime } from '../native/hardwareRuntime';
-import { vaultDeleteSecret, vaultGetSecret, vaultSetSecret } from '../security/secretVault';
+} from './contracts.js';
+import type { HardwareRuntime } from '../native/hardwareRuntime.js';
+import { vaultDeleteSecret, vaultGetSecret, vaultSetSecret } from '../security/secretVault.js';
 
 export function registerIpcHandlers(runtime: HardwareRuntime): void {
   ipcMain.handle(ipcChannels.listDevices, () => runtime.listDevices());

--- a/desktop/main.ts
+++ b/desktop/main.ts
@@ -1,16 +1,16 @@
 import { app, BrowserWindow, dialog, session } from 'electron';
 import { autoUpdater } from 'electron-updater';
-import { registerIpcHandlers } from './ipc/handlers';
-import { HardwareRuntime } from './native/hardwareRuntime';
-import { verifyRuntimeIntegrity } from './security/integrity';
-import { checkProjectCompatibility, configureAutoUpdate } from './release/updatePolicy';
+import { registerIpcHandlers } from './ipc/handlers.js';
+import { HardwareRuntime } from './native/hardwareRuntime.js';
+import { verifyRuntimeIntegrity } from './security/integrity.js';
+import { checkProjectCompatibility, configureAutoUpdate } from './release/updatePolicy.js';
 
 const runtime = new HardwareRuntime();
 
 
 function maybeCheckProjectCompatibility(): void {
   const projectFormatVersion = Number(process.env.LIGHTAI_PROJECT_FORMAT_VERSION ?? 1);
-  const compatibility = checkProjectCompatibility(projectFormatVersion);
+  const compatibility = checkProjectCompatibility(app.getVersion(), projectFormatVersion);
 
   if (!compatibility.ok) {
     throw new Error(compatibility.reason ?? 'Project compatibility check failed.');
@@ -68,7 +68,7 @@ function createWindow(): void {
     width: 1440,
     height: 900,
     webPreferences: {
-      preload: new URL('./preload.ts', import.meta.url).pathname,
+      preload: new URL('./preload.js', import.meta.url).pathname,
       contextIsolation: true,
       nodeIntegration: false,
       sandbox: true,

--- a/desktop/native/hardwareAdapters.ts
+++ b/desktop/native/hardwareAdapters.ts
@@ -1,4 +1,4 @@
-import type { DeviceProtocol, SendFrameRequest } from '../ipc/contracts';
+import type { DeviceProtocol, SendFrameRequest } from '../ipc/contracts.js';
 
 export type HardwareAdapterHealth = {
   connected: boolean;

--- a/desktop/native/hardwareRuntime.ts
+++ b/desktop/native/hardwareRuntime.ts
@@ -1,4 +1,4 @@
-import { IPC_CONTRACT_VERSION, type ConnectDeviceRequest, type HardwareDevice, type RuntimeStatus, type SendFrameRequest } from '../ipc/contracts';
+import { IPC_CONTRACT_VERSION, type ConnectDeviceRequest, type HardwareDevice, type RuntimeStatus, type SendFrameRequest } from '../ipc/contracts.js';
 import {
   ArtnetAdapter,
   DmxUsbAdapter,
@@ -7,7 +7,7 @@ import {
   type HardwareAdapter,
   type HardwareAdapterHealth,
   type ReconnectState
-} from './hardwareAdapters';
+} from './hardwareAdapters.js';
 
 const mockDevices: HardwareDevice[] = [
   { id: 'dmx-usb-001', name: 'USB DMX Interface', protocol: 'dmx', online: true },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -5,15 +5,16 @@
   "private": true,
   "version": "0.1.0",
   "type": "module",
-  "main": "main.ts",
+  "main": "dist/main.js",
   "scripts": {
     "dev": "electron .",
-    "build": "electron-builder --config ./electron-builder.yml",
+    "build": "npm run compile && electron-builder --config ./electron-builder.yml",
     "sign:build": "node ./scripts/sign-build.mjs",
     "build:mac": "electron-builder --mac --config ./electron-builder.yml",
     "build:win": "electron-builder --win --config ./electron-builder.yml",
     "build:dir": "electron-builder --dir --config ./electron-builder.yml",
-    "release:compat": "node ../scripts/release/verify-project-compat.mjs"
+    "release:compat": "node ../scripts/release/verify-project-compat.mjs",
+    "compile": "tsc -p tsconfig.json"
   },
   "devDependencies": {
     "electron": "^31.7.7",

--- a/desktop/preload.ts
+++ b/desktop/preload.ts
@@ -1,6 +1,6 @@
 import { contextBridge, ipcRenderer } from 'electron';
-import { ipcChannels } from './ipc/contracts';
-import type { NativeIpcApi } from './ipc/contracts';
+import { ipcChannels } from './ipc/contracts.js';
+import type { NativeIpcApi } from './ipc/contracts.js';
 
 const api: NativeIpcApi = {
   listDevices: () => ipcRenderer.invoke(ipcChannels.listDevices),

--- a/desktop/tsconfig.json
+++ b/desktop/tsconfig.json
@@ -5,7 +5,14 @@
     "moduleResolution": "NodeNext",
     "strict": true,
     "skipLibCheck": true,
-    "types": ["node", "electron"]
+    "types": [
+      "node",
+      "electron"
+    ],
+    "rootDir": ".",
+    "outDir": "dist"
   },
-  "include": ["./**/*.ts"]
+  "include": [
+    "./**/*.ts"
+  ]
 }


### PR DESCRIPTION
### Motivation
- Produce compiled JavaScript for the Electron desktop app so `electron-builder` packages `dist` artifacts rather than TypeScript sources.
- Ensure runtime ESM imports and preload path reference compiled `.js` outputs produced by `tsc`.

### Description
- Update `desktop/tsconfig.json` to set `rootDir` and `outDir` (`dist`) and keep `target/module` as `ES2022`/`NodeNext` so `tsc` emits runtime JS (`desktop/tsconfig.json`).
- Change `desktop/package.json` to set `main` to `dist/main.js`, add a `compile` script (`tsc -p tsconfig.json`), and run it before `electron-builder` in `build` (`desktop/package.json`).
- Modify `desktop/electron-builder.yml` to include compiled files (`./dist/**`) and set `extraMetadata.main` to `dist/main.js` so the packaged app points to the compiled entry (`desktop/electron-builder.yml`).
- Update Electron entry code and related modules to import compiled ESM paths (append `.js`) and change the preload path to `preload.js`, and adapt the `checkProjectCompatibility` call to pass `app.getVersion()` where needed (`desktop/main.ts`, `desktop/preload.ts`, `desktop/ipc/*`, `desktop/native/*`).

### Testing
- Ran `npm run compile` in `desktop` which invokes `tsc -p tsconfig.json`, and the TypeScript compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04a8c042c4832a84ed3a7433ae27a4)