### PR TITLE
Handle missing Supabase configuration (non-blocking)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,7 @@ import {
 import { effects } from './lib/effects';
 import { buildIncidentReport, downloadIncidentReport, observability } from './lib/observability';
 import { runtimeClient } from './lib/runtimeClient';
-import { supabase } from './lib/supabase';
+import { SUPABASE_DISABLED_MESSAGE, supabase } from './lib/supabase';
 import { emitAiSuggestionEvent } from './lib/aiSuggestionTelemetry';
 import type { CollaborationConflict, GuidedMergeResolution } from './lib/collaborationStrategy';
 
@@ -100,7 +100,7 @@ function App() {
 
       observability.info('preset-audit', action, technicalAudit);
 
-      if (!profileState.profile) {
+      if (!profileState.profile || !supabase) {
         return;
       }
 
@@ -123,7 +123,7 @@ function App() {
 
   const logEffectUsage = useCallback(
     async (effectName: string, configuration: Record<string, unknown>) => {
-      if (!profileState.profile) return;
+      if (!profileState.profile || !supabase) return;
 
       const { error } = await supabase.from('effect_history').insert([
         {
@@ -351,6 +351,11 @@ function App() {
     <AppStateProvider value={appState}>
       <div className="min-h-screen bg-gradient-to-b from-black to-gray-900 text-white">
         <Toaster position="top-right" />
+        {!supabase && (
+          <div className="fixed left-1/2 top-24 z-50 w-[min(90vw,42rem)] -translate-x-1/2 rounded-lg border border-yellow-400/40 bg-yellow-400/10 px-4 py-3 text-center text-sm text-yellow-100 shadow-xl backdrop-blur">
+            {SUPABASE_DISABLED_MESSAGE}
+          </div>
+        )}
         <AuthModal isOpen={profileState.isAuthModalOpen} onClose={profileState.closeAuthModal} />
 
         <EffectSidePanel onLoadPreset={handleLoadPreset} onLoadConfiguration={handleLoadConfiguration} />

--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { X } from 'lucide-react';
-import { supabase } from '../lib/supabase';
+import { SUPABASE_DISABLED_MESSAGE, supabase } from '../lib/supabase';
 import toast from 'react-hot-toast';
 import { runtimeClient } from '../lib/runtimeClient';
 
@@ -103,6 +103,33 @@ export function AuthModal({ isOpen, onClose }: AuthModalProps) {
 
   if (!isOpen) return null;
 
+  if (!supabase) {
+    return (
+      <div className="fixed inset-0 bg-black/50 backdrop-blur-lg flex items-center justify-center z-50">
+        <div className="bg-gray-900 p-8 rounded-xl w-full max-w-md relative space-y-4">
+          <button
+            onClick={onClose}
+            className="absolute top-4 right-4 text-gray-400 hover:text-white"
+            aria-label="Close authentication modal"
+          >
+            <X className="w-6 h-6" />
+          </button>
+          <h2 className="text-2xl font-bold gradient-text">Authentication unavailable</h2>
+          <div className="rounded-lg border border-yellow-400/40 bg-yellow-400/10 p-3 text-sm text-yellow-100">
+            {SUPABASE_DISABLED_MESSAGE}
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="w-full bg-yellow-400 text-black font-semibold py-2 rounded-lg hover:bg-yellow-300 transition-colors"
+          >
+            Continue without Supabase
+          </button>
+        </div>
+      </div>
+    );
+  }
+
   const persistCredentials = async (): Promise<void> => {
     if (rememberSecurely) {
       await runtimeClient.vaultSetSecret({
@@ -118,6 +145,11 @@ export function AuthModal({ isOpen, onClose }: AuthModalProps) {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setFormError(null);
+
+    if (!supabase) {
+      setFormError(SUPABASE_DISABLED_MESSAGE);
+      return;
+    }
 
     if (!isLogin && !passwordPolicy.isValid) {
       setFormError('Password policy is not satisfied. Review all requirements before creating the account.');

--- a/src/components/EffectHistoryList.tsx
+++ b/src/components/EffectHistoryList.tsx
@@ -1,7 +1,7 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { ArrowUpRight, Clock } from 'lucide-react';
 import toast from 'react-hot-toast';
-import { supabase, type EffectHistory } from '../lib/supabase';
+import { SUPABASE_DISABLED_MESSAGE, supabase, type EffectHistory } from '../lib/supabase';
 
 type EffectHistoryListProps = {
   userId: string;
@@ -11,11 +11,12 @@ type EffectHistoryListProps = {
 export function EffectHistoryList({ userId, onLoadConfiguration }: EffectHistoryListProps) {
   const [history, setHistory] = useState<EffectHistory[]>([]);
 
-  useEffect(() => {
-    void fetchHistory();
-  }, [userId]);
+  const fetchHistory = useCallback(async () => {
+    if (!supabase) {
+      setHistory([]);
+      return;
+    }
 
-  const fetchHistory = async () => {
     const { data, error } = await supabase
       .from('effect_history')
       .select('*')
@@ -29,7 +30,11 @@ export function EffectHistoryList({ userId, onLoadConfiguration }: EffectHistory
     }
 
     setHistory(data || []);
-  };
+  }, [userId]);
+
+  useEffect(() => {
+    void fetchHistory();
+  }, [fetchHistory]);
 
   const formatDate = (dateString: string) => {
     const date = new Date(dateString);
@@ -47,6 +52,12 @@ export function EffectHistoryList({ userId, onLoadConfiguration }: EffectHistory
         <Clock className="w-5 h-5 text-yellow-400" />
         <h3 className="text-xl font-semibold">Recent Effects</h3>
       </div>
+
+      {!supabase && (
+        <div className="rounded-lg border border-yellow-400/40 bg-yellow-400/10 p-3 text-sm text-yellow-100">
+          {SUPABASE_DISABLED_MESSAGE}
+        </div>
+      )}
 
       <div className="space-y-2">
         {history.map((item) => (

--- a/src/components/PresetManager.tsx
+++ b/src/components/PresetManager.tsx
@@ -1,8 +1,8 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Save, Share2, Trash2 } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { prepareConfigurationForStorage } from '../lib/effectConfiguration';
-import { supabase, type Preset } from '../lib/supabase';
+import { SUPABASE_DISABLED_MESSAGE, supabase, type Preset } from '../lib/supabase';
 
 type PresetManagerProps = {
   userId: string;
@@ -21,11 +21,12 @@ export function PresetManager({
   const [newPresetName, setNewPresetName] = useState('');
   const [isCreating, setIsCreating] = useState(false);
 
-  useEffect(() => {
-    void fetchPresets();
-  }, [userId]);
+  const fetchPresets = useCallback(async () => {
+    if (!supabase) {
+      setPresets([]);
+      return;
+    }
 
-  const fetchPresets = async () => {
     const { data, error } = await supabase
       .from('presets')
       .select('*')
@@ -38,11 +39,20 @@ export function PresetManager({
     }
 
     setPresets(data || []);
-  };
+  }, [userId]);
+
+  useEffect(() => {
+    void fetchPresets();
+  }, [fetchPresets]);
 
   const savePreset = async () => {
     if (!newPresetName.trim()) {
       toast.error('Please enter a preset name');
+      return;
+    }
+
+    if (!supabase) {
+      toast.error(SUPABASE_DISABLED_MESSAGE);
       return;
     }
 
@@ -68,6 +78,11 @@ export function PresetManager({
   };
 
   const deletePreset = async (presetId: string) => {
+    if (!supabase) {
+      toast.error(SUPABASE_DISABLED_MESSAGE);
+      return;
+    }
+
     const { error } = await supabase.from('presets').delete().eq('id', presetId);
 
     if (error) {
@@ -91,11 +106,18 @@ export function PresetManager({
         <h3 className="text-xl font-semibold">My Presets</h3>
         <button
           onClick={() => setIsCreating(true)}
-          className="bg-yellow-400 text-black px-4 py-2 rounded-lg hover:bg-yellow-300 transition-colors"
+          disabled={!supabase}
+          className="bg-yellow-400 text-black px-4 py-2 rounded-lg hover:bg-yellow-300 transition-colors disabled:cursor-not-allowed disabled:opacity-50"
         >
           Save Current
         </button>
       </div>
+
+      {!supabase && (
+        <div className="rounded-lg border border-yellow-400/40 bg-yellow-400/10 p-3 text-sm text-yellow-100">
+          {SUPABASE_DISABLED_MESSAGE}
+        </div>
+      )}
 
       {isCreating && (
         <div className="flex gap-2">

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { LogOut, User } from 'lucide-react';
-import { supabase } from '../lib/supabase';
+import { SUPABASE_DISABLED_MESSAGE, supabase } from '../lib/supabase';
 import type { Profile } from '../lib/supabase';
 
 type UserMenuProps = {
@@ -9,6 +9,10 @@ type UserMenuProps = {
 
 export function UserMenu({ profile }: UserMenuProps) {
   const handleSignOut = async () => {
+    if (!supabase) {
+      return;
+    }
+
     await supabase.auth.signOut();
   };
 
@@ -19,10 +23,16 @@ export function UserMenu({ profile }: UserMenuProps) {
         <span>{profile.username}</span>
       </button>
       
-      <div className="absolute right-0 mt-2 w-48 py-2 bg-gray-900 rounded-lg shadow-xl opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
+      <div className="absolute right-0 mt-2 w-64 py-2 bg-gray-900 rounded-lg shadow-xl opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
+        {!supabase && (
+          <div className="px-4 py-2 text-xs text-yellow-100">
+            {SUPABASE_DISABLED_MESSAGE}
+          </div>
+        )}
         <button
           onClick={handleSignOut}
-          className="w-full px-4 py-2 text-left flex items-center space-x-2 hover:bg-gray-800 transition-colors"
+          disabled={!supabase}
+          className="w-full px-4 py-2 text-left flex items-center space-x-2 hover:bg-gray-800 transition-colors disabled:cursor-not-allowed disabled:opacity-50"
         >
           <LogOut className="w-4 h-4" />
           <span>Sign Out</span>

--- a/src/hooks/useSupabaseProfile.ts
+++ b/src/hooks/useSupabaseProfile.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { supabase, type Profile } from '../lib/supabase';
+import { SUPABASE_DISABLED_MESSAGE, supabase, type Profile } from '../lib/supabase';
 import { observability } from '../lib/observability';
 
 export function useSupabaseProfile() {
@@ -7,6 +7,11 @@ export function useSupabaseProfile() {
   const [isAuthModalOpen, setIsAuthModalOpen] = useState(false);
 
   const fetchProfile = useCallback(async (userId: string) => {
+    if (!supabase) {
+      observability.warn('useSupabaseProfile', SUPABASE_DISABLED_MESSAGE, { userId }, ['auth', 'configuration']);
+      return;
+    }
+
     const { data, error } = await supabase
       .from('profiles')
       .select('*')
@@ -26,6 +31,12 @@ export function useSupabaseProfile() {
   }, []);
 
   useEffect(() => {
+    if (!supabase) {
+      observability.warn('useSupabaseProfile', SUPABASE_DISABLED_MESSAGE, undefined, ['auth', 'configuration']);
+      setProfile(null);
+      return;
+    }
+
     const handleReconnect = () => {
       observability.incident('recovered', 'Client reconnected, refreshing authenticated profile');
       supabase.auth.getSession().then(({ data: { session } }) => {

--- a/src/lib/aiSuggestionTelemetry.ts
+++ b/src/lib/aiSuggestionTelemetry.ts
@@ -1,4 +1,4 @@
-import { supabase } from './supabase';
+import { SUPABASE_DISABLED_MESSAGE, supabase } from './supabase';
 import { observability } from './observability';
 
 export type AiSuggestionEventType =
@@ -50,6 +50,13 @@ export const pseudonymizeOperatorId = async (operatorId: string): Promise<string
 };
 
 export const emitAiSuggestionEvent = async (input: AiSuggestionEventInput): Promise<void> => {
+  if (!supabase) {
+    observability.warn('ai-suggestion-telemetry', SUPABASE_DISABLED_MESSAGE, {
+      eventType: input.eventType,
+    });
+    return;
+  }
+
   const operatorPseudoId = await pseudonymizeOperatorId(input.operatorId);
   const { error } = await supabase.from('ai_suggestion_events').insert([
     {

--- a/src/lib/liveCollaboration.ts
+++ b/src/lib/liveCollaboration.ts
@@ -1,4 +1,4 @@
-import { supabase } from './supabase';
+import { SUPABASE_DISABLED_MESSAGE, supabase } from './supabase';
 import { observability } from './observability';
 
 export type ProjectRole = 'owner' | 'operator' | 'viewer';
@@ -56,6 +56,11 @@ export async function syncSharedShowState<TState extends Record<string, unknown>
     throw new Error('offline_sync_deferred');
   }
 
+  if (!supabase) {
+    observability.warn('liveCollaboration', SUPABASE_DISABLED_MESSAGE, { sharedShowId }, ['configuration', 'sync']);
+    throw new Error(SUPABASE_DISABLED_MESSAGE);
+  }
+
   const { data, error } = await supabase.rpc('sync_shared_show_state', {
     p_shared_show_id: sharedShowId,
     p_expected_version: expectedVersion,
@@ -87,6 +92,11 @@ export async function logCueAction(params: {
   actionType?: string;
   payload?: Record<string, unknown>;
 }): Promise<void> {
+  if (!supabase) {
+    observability.warn('liveCollaboration', SUPABASE_DISABLED_MESSAGE, { projectId: params.projectId }, ['configuration', 'journal']);
+    throw new Error(SUPABASE_DISABLED_MESSAGE);
+  }
+
   const { error } = await supabase.rpc('log_cue_action', {
     p_project_id: params.projectId,
     p_shared_show_id: params.sharedShowId,
@@ -108,6 +118,11 @@ export async function acquireLiveControlLock(params: {
   sessionId: string;
   ttlSeconds?: number;
 }): Promise<LiveControlLock> {
+  if (!supabase) {
+    observability.warn('liveCollaboration', SUPABASE_DISABLED_MESSAGE, { projectId: params.projectId }, ['configuration', 'lock']);
+    throw new Error(SUPABASE_DISABLED_MESSAGE);
+  }
+
   const { data, error } = await supabase.rpc('acquire_live_control_lock', {
     p_project_id: params.projectId,
     p_session_id: params.sessionId,
@@ -139,6 +154,12 @@ export async function heartbeatLiveControlLock(params: {
     }, ['offline', 'lock']);
     throw new Error('offline_heartbeat_skipped');
   }
+
+  if (!supabase) {
+    observability.warn('liveCollaboration', SUPABASE_DISABLED_MESSAGE, { projectId: params.projectId }, ['configuration', 'lock']);
+    throw new Error(SUPABASE_DISABLED_MESSAGE);
+  }
+
   const { data, error } = await supabase.rpc('heartbeat_live_control_lock', {
     p_project_id: params.projectId,
     p_session_id: params.sessionId,
@@ -153,6 +174,11 @@ export async function heartbeatLiveControlLock(params: {
 }
 
 export async function releaseLiveControlLock(projectId: string, sessionId: string): Promise<boolean> {
+  if (!supabase) {
+    observability.warn('liveCollaboration', SUPABASE_DISABLED_MESSAGE, { projectId }, ['configuration', 'lock']);
+    throw new Error(SUPABASE_DISABLED_MESSAGE);
+  }
+
   const { data, error } = await supabase.rpc('release_live_control_lock', {
     p_project_id: projectId,
     p_session_id: sessionId

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -3,11 +3,13 @@ import { createClient } from '@supabase/supabase-js';
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
-if (!supabaseUrl || !supabaseAnonKey) {
-  throw new Error('Missing Supabase environment variables');
-}
+export const SUPABASE_DISABLED_MESSAGE = 'Supabase is not configured. Authentication and cloud presets are disabled.';
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+export const isSupabaseConfigured = Boolean(supabaseUrl && supabaseAnonKey);
+
+export const supabase = isSupabaseConfigured
+  ? createClient(supabaseUrl, supabaseAnonKey)
+  : null;
 
 export type Profile = {
   id: string;


### PR DESCRIPTION
### Motivation
- Prevent the app from throwing and failing to start when Supabase env vars are not provided, so the UI still loads.
- Show a clear user-facing message when Supabase is unavailable and disable auth/cloud preset features rather than crashing the app.

### Description
- Replace the blocking env-var check in `src/lib/supabase.ts` with `isSupabaseConfigured`, a `SUPABASE_DISABLED_MESSAGE` constant and a nullable `supabase` export (`createClient(...) : null`).
- Add guards and fallback behavior to Supabase consumers so they handle `supabase === null` in `src/App.tsx`, `src/hooks/useSupabaseProfile.ts`, `src/components/AuthModal.tsx`, `src/components/UserMenu.tsx`, `src/components/PresetManager.tsx`, and `src/components/EffectHistoryList.tsx` and show the message `Supabase is not configured. Authentication and cloud presets are disabled.` where appropriate.
- Add non-blocking checks in telemetry and collaboration helpers (`src/lib/aiSuggestionTelemetry.ts`, `src/lib/liveCollaboration.ts`) so indirect consumers log warnings and avoid dereferencing a null client.
- Surface a persistent UI banner in `App` and an informational modal in `AuthModal` to indicate Supabase is disabled, and disable or no-op Supabase actions (save/delete presets, sign out, history fetch, telemetry, RPCs) when unconfigured.

### Testing
- Ran `npm run build` and the build completed successfully.
- Ran `npm run lint` which reported pre-existing lint errors in unrelated files (errors remain and are not introduced by this change).
- Started the dev server with `npm run dev -- --host 127.0.0.1` and Vite served the app successfully.  
- Attempted an automated page screenshot with Playwright but it failed because `playwright` and a browser binary are not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04a98cd540832a88fbd4d2669908ac)