### PR TITLE
Add startup ErrorBoundary and guard missing #root

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,48 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+type ErrorBoundaryProps = {
+  children: ReactNode;
+};
+
+type ErrorBoundaryState = {
+  error: Error | null;
+};
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = {
+    error: null,
+  };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error('Application failed to start', error, errorInfo);
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <main className="min-h-screen bg-gray-950 px-6 py-16 text-gray-100">
+          <section className="mx-auto max-w-2xl rounded-2xl border border-red-500/40 bg-red-950/30 p-8 shadow-2xl shadow-red-950/20">
+            <p className="text-sm font-semibold uppercase tracking-[0.3em] text-red-300">Startup error</p>
+            <h1 className="mt-3 text-3xl font-bold text-white">Application failed to start</h1>
+            <div className="mt-6 rounded-xl border border-red-400/30 bg-black/30 p-4">
+              <p className="text-sm font-medium text-red-100">Error message</p>
+              <p className="mt-2 whitespace-pre-wrap break-words font-mono text-sm text-red-50">
+                {this.state.error.message || 'An unknown error occurred.'}
+              </p>
+            </div>
+            <p className="mt-6 text-sm leading-6 text-gray-200">
+              Check <code className="rounded bg-white/10 px-1.5 py-0.5 text-red-100">.env.local</code> and the browser
+              console for more details.
+            </p>
+          </section>
+        </main>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,19 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
+import { ErrorBoundary } from './components/ErrorBoundary';
 import './index.css';
 
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <App />
-  </StrictMode>
-);
+const rootElement = document.getElementById('root');
+
+if (!rootElement) {
+  console.error("Application failed to start: root element '#root' was not found.");
+} else {
+  createRoot(rootElement).render(
+    <StrictMode>
+      <ErrorBoundary>
+        <App />
+      </ErrorBoundary>
+    </StrictMode>
+  );
+}


### PR DESCRIPTION
### Motivation

- Provide a clear, user-facing fallback when the app throws during startup instead of crashing silently. 
- Surface the actual error message and give an immediate next step to check `.`env.local` and the browser console. 
- Avoid using a silent non-null assertion for the root container and log an explicit error if `#root` is missing.

### Description

- Add `src/components/ErrorBoundary.tsx`, a React class error boundary that captures errors with `getDerivedStateFromError` and `componentDidCatch`, logs `Application failed to start` to the console, and renders a styled fallback showing the title `Application failed to start`, the error message, and the suggestion to check `.env.local` and the browser console. 
- Update `src/main.tsx` to import `ErrorBoundary`, check `document.getElementById('root')` before calling `createRoot`, and log a clear console error when the root element is not found. 
- Wrap the rendered `<App />` with `<ErrorBoundary>` inside the `createRoot(...).render(...)` call so startup errors are caught and displayed.

### Testing

- `npm run build` completed successfully and produced a production build. 
- `npm run lint` reported failures due to pre-existing lint errors in unrelated files (notably `src/lib/effects.ts` and several runtime adapter files) and therefore did not pass. 
- ESLint also emitted unrelated warnings in other files but no new lint issues were introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04ad1ca2f8832a8c27893811eaea14)