### PR TITLE
Add root desktop:check script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "desktop:dev": "npm run dev --prefix desktop",
+    "desktop:check": "npm run build && npm run compile --prefix desktop",
     "desktop:build": "npm run build && npm run build --prefix desktop",
     "desktop:build:win": "npm run build && npm run build:win --prefix desktop",
     "test": "node scripts/run-tests.mjs",


### PR DESCRIPTION
### Motivation

- Ajouter un script racine `desktop:check` pour échouer tôt si la build Vite ou la compilation TypeScript du shell desktop échoue et vérifier les imports desktop avant le packaging.

### Description

- Ajouté dans `package.json` racine la ligne `"desktop:check": "npm run build && npm run compile --prefix desktop"`; le script `compile` existe déjà dans `desktop/package.json` (`tsc -p tsconfig.json`).

### Testing

- Exécuté `npm run desktop:check` qui a construit le frontend avec Vite puis lancé `tsc` dans `desktop` et s'est terminé avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04af667a44832aa5f38b08c96b3749)