### PR TITLE
Guard desktop runtime features in browser mode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import {
 import { effects } from './lib/effects';
 import { buildIncidentReport, downloadIncidentReport, observability } from './lib/observability';
 import { runtimeClient } from './lib/runtimeClient';
+import { isWebRuntime } from './lib/runtimeEnvironment';
 import { SUPABASE_DISABLED_MESSAGE, supabase } from './lib/supabase';
 import { emitAiSuggestionEvent } from './lib/aiSuggestionTelemetry';
 import type { CollaborationConflict, GuidedMergeResolution } from './lib/collaborationStrategy';
@@ -78,6 +79,11 @@ function App() {
     };
 
     pollStatus();
+
+    if (isWebRuntime) {
+      return undefined;
+    }
+
     const id = window.setInterval(pollStatus, 1000);
     return () => clearInterval(id);
   }, []);

--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -3,6 +3,7 @@ import { X } from 'lucide-react';
 import { SUPABASE_DISABLED_MESSAGE, supabase } from '../lib/supabase';
 import toast from 'react-hot-toast';
 import { runtimeClient } from '../lib/runtimeClient';
+import { DESKTOP_RUNTIME_UNAVAILABLE_MESSAGE, isDesktopRuntime, isWebRuntime } from '../lib/runtimeEnvironment';
 
 type AuthModalProps = {
   isOpen: boolean;
@@ -72,9 +73,15 @@ export function AuthModal({ isOpen, onClose }: AuthModalProps) {
   const [failedAttempts, setFailedAttempts] = useState(0);
 
   const passwordPolicy = useMemo(() => evaluatePasswordPolicy(password, email), [password, email]);
+  const canUseSecureVault = isDesktopRuntime;
 
   useEffect(() => {
     if (!isOpen) {
+      return;
+    }
+
+    if (!canUseSecureVault) {
+      setRememberSecurely(false);
       return;
     }
 
@@ -99,7 +106,7 @@ export function AuthModal({ isOpen, onClose }: AuthModalProps) {
     return () => {
       isCancelled = true;
     };
-  }, [isOpen]);
+  }, [canUseSecureVault, isOpen]);
 
   if (!isOpen) return null;
 
@@ -131,6 +138,10 @@ export function AuthModal({ isOpen, onClose }: AuthModalProps) {
   }
 
   const persistCredentials = async (): Promise<void> => {
+    if (!canUseSecureVault) {
+      return;
+    }
+
     if (rememberSecurely) {
       await runtimeClient.vaultSetSecret({
         key: CREDENTIALS_VAULT_KEY,
@@ -273,14 +284,22 @@ export function AuthModal({ isOpen, onClose }: AuthModalProps) {
             </div>
           )}
 
-          <label className="flex items-center gap-2 text-sm text-gray-300">
-            <input
-              type="checkbox"
-              checked={rememberSecurely}
-              onChange={(e) => setRememberSecurely(e.target.checked)}
-            />
-            Remember credentials in secure local vault
-          </label>
+          <div className="space-y-2">
+            <label className={`flex items-center gap-2 text-sm ${canUseSecureVault ? 'text-gray-300' : 'text-gray-500'}`}>
+              <input
+                type="checkbox"
+                checked={canUseSecureVault && rememberSecurely}
+                disabled={!canUseSecureVault}
+                onChange={(e) => setRememberSecurely(e.target.checked)}
+              />
+              Remember credentials in secure local vault
+            </label>
+            {isWebRuntime && (
+              <div className="rounded-lg border border-yellow-400/40 bg-yellow-400/10 p-3 text-xs text-yellow-100">
+                {DESKTOP_RUNTIME_UNAVAILABLE_MESSAGE}
+              </div>
+            )}
+          </div>
 
           {formError && (
             <div className="rounded-lg border border-red-500/50 bg-red-500/10 p-3 text-sm text-red-300">

--- a/src/components/layout/DiagnosticsPanel.tsx
+++ b/src/components/layout/DiagnosticsPanel.tsx
@@ -1,5 +1,6 @@
 import { AlertTriangle, Download, Shield } from 'lucide-react';
 import { useAppState } from '../../context/AppStateContext';
+import { DESKTOP_RUNTIME_UNAVAILABLE_MESSAGE, isWebRuntime } from '../../lib/runtimeEnvironment';
 
 export function DiagnosticsPanel() {
   const { diagnostics } = useAppState();
@@ -26,12 +27,20 @@ export function DiagnosticsPanel() {
         </div>
 
         <div className="bg-gray-900/80 rounded-lg p-3 space-y-1">
-          <div className="font-medium">Runtime</div>
-          <div>Ready: {runtimeStatus.ready ? 'yes' : 'no'}</div>
-          <div>Protocol: {runtimeStatus.protocol ?? 'none'}</div>
-          <div>Queue: {runtimeStatus.metrics.protocolQueueDepth}</div>
-          <div>Queue max: {runtimeStatus.metrics.protocolQueueHighWatermark}</div>
-          <div>Dropped protocol frames: {runtimeStatus.metrics.protocolDroppedFrames}</div>
+          <div className="font-medium">Runtime Electron</div>
+          {isWebRuntime ? (
+            <div className="rounded-lg border border-yellow-400/40 bg-yellow-400/10 p-3 text-xs text-yellow-100">
+              {DESKTOP_RUNTIME_UNAVAILABLE_MESSAGE}
+            </div>
+          ) : (
+            <>
+              <div>Ready: {runtimeStatus.ready ? 'yes' : 'no'}</div>
+              <div>Protocol: {runtimeStatus.protocol ?? 'none'}</div>
+              <div>Queue: {runtimeStatus.metrics.protocolQueueDepth}</div>
+              <div>Queue max: {runtimeStatus.metrics.protocolQueueHighWatermark}</div>
+              <div>Dropped protocol frames: {runtimeStatus.metrics.protocolDroppedFrames}</div>
+            </>
+          )}
         </div>
 
         <div className="bg-gray-900/80 rounded-lg p-3 space-y-1">

--- a/src/components/layout/MarketingSections.tsx
+++ b/src/components/layout/MarketingSections.tsx
@@ -11,6 +11,7 @@ import {
   Wand2,
   Zap
 } from 'lucide-react';
+import { DESKTOP_RUNTIME_UNAVAILABLE_MESSAGE, isWebRuntime } from '../../lib/runtimeEnvironment';
 
 const features = [
   {
@@ -31,12 +32,14 @@ const features = [
   {
     icon: <Network className="w-8 h-8 text-yellow-400" />,
     title: 'Exécution distribuée (beta)',
-    description: 'Traitement multi-processus disponible sur certains scénarios runtime.'
+    description: 'Traitement multi-processus disponible sur certains scénarios runtime.',
+    desktopOnly: true
   },
   {
     icon: <Cpu className="w-8 h-8 text-yellow-400" />,
     title: 'Accélération matérielle (selon machine)',
-    description: 'Utilisation des capacités matérielles locales quand disponibles.'
+    description: 'Utilisation des capacités matérielles locales quand disponibles.',
+    desktopOnly: true
   },
   {
     icon: <Globe className="w-8 h-8 text-yellow-400" />,
@@ -56,7 +59,8 @@ const features = [
   {
     icon: <Zap className="w-8 h-8 text-yellow-400" />,
     title: 'Traitement temps réel',
-    description: 'Pilotage temps réel optimisé; performances dépendantes du matériel et des protocoles.'
+    description: 'Pilotage temps réel optimisé; performances dépendantes du matériel et des protocoles DMX natifs.',
+    desktopOnly: true
   }
 ];
 
@@ -67,16 +71,35 @@ export function MarketingSections() {
         <div className="max-w-7xl mx-auto">
           <h2 className="text-5xl font-bold text-center mb-16 gradient-text">Fonctionnalités produit</h2>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-            {features.map((feature) => (
-              <div
-                key={feature.title}
-                className="card-3d bg-gray-800/50 backdrop-blur-lg rounded-xl p-6 hover:bg-gray-800/70 transition-all cursor-pointer"
-              >
-                <div className="mb-4">{feature.icon}</div>
-                <h3 className="text-xl font-semibold mb-2">{feature.title}</h3>
-                <p className="text-gray-400">{feature.description}</p>
-              </div>
-            ))}
+            {features.map((feature) => {
+              const isDisabled = isWebRuntime && feature.desktopOnly;
+
+              return (
+                <div
+                  key={feature.title}
+                  className={`card-3d bg-gray-800/50 backdrop-blur-lg rounded-xl p-6 transition-all ${
+                    isDisabled ? 'cursor-not-allowed opacity-55' : 'cursor-pointer hover:bg-gray-800/70'
+                  }`}
+                  aria-disabled={isDisabled}
+                >
+                  <div className="mb-4">{feature.icon}</div>
+                  <div className="mb-2 flex items-center justify-between gap-3">
+                    <h3 className="text-xl font-semibold">{feature.title}</h3>
+                    {feature.desktopOnly && (
+                      <span className="rounded-full border border-yellow-400/40 px-2 py-0.5 text-xs text-yellow-200">
+                        Desktop
+                      </span>
+                    )}
+                  </div>
+                  <p className="text-gray-400">{feature.description}</p>
+                  {isDisabled && (
+                    <p className="mt-3 rounded-lg border border-yellow-400/40 bg-yellow-400/10 p-2 text-xs text-yellow-100">
+                      {DESKTOP_RUNTIME_UNAVAILABLE_MESSAGE}
+                    </p>
+                  )}
+                </div>
+              );
+            })}
           </div>
         </div>
       </section>

--- a/src/lib/runtimeClient.ts
+++ b/src/lib/runtimeClient.ts
@@ -10,12 +10,15 @@ import type {
 } from '../../desktop/ipc/contracts';
 import { assertRuntimeStatus as assertRuntimeStatusPayload, IPC_CONTRACT_VERSION as EXPECTED_IPC_CONTRACT_VERSION } from '../../desktop/ipc/contracts';
 import { observability } from './observability';
+import { DESKTOP_RUNTIME_UNAVAILABLE_MESSAGE, isDesktopRuntime } from './runtimeEnvironment';
 
 const fallbackStatus: RuntimeStatus = {
   contractVersion: EXPECTED_IPC_CONTRACT_VERSION,
   ready: false,
   connectedDeviceId: null,
   protocol: null,
+  dryRun: true,
+  deviceStatus: null,
   metrics: {
     protocolQueueDepth: 0,
     protocolQueueHighWatermark: 0,
@@ -23,12 +26,11 @@ const fallbackStatus: RuntimeStatus = {
   }
 };
 
-const unavailableError =
-  'Native runtime unavailable. Start the desktop shell to access hardware protocols.';
+const unavailableError = DESKTOP_RUNTIME_UNAVAILABLE_MESSAGE;
 const incompatibleRuntimeErrorPrefix = 'Incompatible native runtime contract';
 
 function getNativeApi(): NativeIpcApi {
-  if (!window.lightAiNative) {
+  if (!isDesktopRuntime || !window.lightAiNative) {
     throw new Error(unavailableError);
   }
   return window.lightAiNative;
@@ -51,7 +53,7 @@ export const runtimeClient = {
     }
   },
   getRuntimeStatus: async (): Promise<RuntimeStatusHandshake> => {
-    if (!window.lightAiNative) {
+    if (!isDesktopRuntime || !window.lightAiNative) {
       observability.warn('runtimeClient', 'Native runtime unavailable, returning fallback status', undefined, [
         'runtime',
         'degraded',

--- a/src/lib/runtimeEnvironment.ts
+++ b/src/lib/runtimeEnvironment.ts
@@ -1,0 +1,5 @@
+export const DESKTOP_RUNTIME_UNAVAILABLE_MESSAGE =
+  'Desktop runtime unavailable. Hardware controls are disabled in browser mode.';
+
+export const isDesktopRuntime = typeof window !== 'undefined' && Boolean(window.lightAiNative);
+export const isWebRuntime = !isDesktopRuntime;


### PR DESCRIPTION
### Motivation
- Provide a single runtime-environment helper to detect desktop (Electron) vs web runtimes and centralize the browser-mode warning message. 
- Prevent runtime- and hardware-dependent features from erroring or being visible in the browser by gating native IPC and vault calls. 
- Surface a clear, consistent message when desktop-only features are unavailable in web builds.

### Description
- Add `src/lib/runtimeEnvironment.ts` exposing `isDesktopRuntime`, `isWebRuntime` and `DESKTOP_RUNTIME_UNAVAILABLE_MESSAGE` for shared runtime checks. 
- Update `src/lib/runtimeClient.ts` to use `isDesktopRuntime`, return a dry-run `fallbackStatus` when native IPC is unavailable, and use the shared unavailable message for thrown errors and warnings. 
- Modify `src/components/AuthModal.tsx` to disable secure vault load/save when not running on desktop and show the desktop-unavailable message beside the vault checkbox. 
- Change `src/components/layout/DiagnosticsPanel.tsx` to show the desktop-unavailable message instead of Electron runtime metrics when in browser mode. 
- Update `src/components/layout/MarketingSections.tsx` to mark specific hardware/runtime/DMX features as `desktopOnly`, visually disable them in browser mode and display the shared warning. 
- Stop repeated runtime-status polling in `src/App.tsx` when running in web mode (initial fallback check remains). 

### Testing
- Ran `npm run build`, which completed successfully. 
- Ran `npm run lint`, which failed due to pre-existing lint/type issues (errors in `src/lib/effects.ts` and unused-parameter warnings in runtime adapters); these failures are unrelated to the changes introduced here. 
- Ran `npm test`, which failed in the environment because the Node test bundle expects Vite `import.meta.env` variables (e.g. `VITE_APP_VERSION`) that are not present in the Node test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04b61aa990832aaf2bc61f39e4db43)