### PR TITLE
Load packaged renderer from local dist

### DIFF
--- a/desktop/main.ts
+++ b/desktop/main.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { app, BrowserWindow, dialog, session } from 'electron';
 import { autoUpdater } from 'electron-updater';
 import { registerIpcHandlers } from './ipc/handlers.js';
@@ -82,8 +83,13 @@ function createWindow(): void {
     event.preventDefault();
   });
 
-  const rendererUrl = process.env.LIGHTAI_UI_URL ?? 'http://localhost:5173';
-  void mainWindow.loadURL(rendererUrl);
+  if (app.isPackaged) {
+    const packagedIndexHtml = path.join(app.getAppPath(), 'dist', 'index.html');
+    void mainWindow.loadFile(packagedIndexHtml);
+  } else {
+    const rendererUrl = process.env.LIGHTAI_UI_URL ?? 'http://localhost:5173';
+    void mainWindow.loadURL(rendererUrl);
+  }
 }
 
 app.whenReady().then(async () => {


### PR DESCRIPTION
### Motivation
- Ensure the Electron main process loads the dev server URL during development but uses the local bundled renderer (`dist/index.html`) when the app is packaged, consistent with the `electron-builder.yml` `../dist/**` inclusion.

### Description
- Add `import path from 'node:path'` and update `createWindow()` in `desktop/main.ts` to branch on `app.isPackaged`, calling `mainWindow.loadFile(path.join(app.getAppPath(), 'dist', 'index.html'))` for packaged builds and preserving the `LIGHTAI_UI_URL` / `http://localhost:5173` `loadURL` behavior for development.

### Testing
- `npm run desktop:check` and `npx tsc -p desktop/tsconfig.json --noEmit` passed; `npm run lint` surfaced pre-existing unrelated lint errors; `npm run build:dir --prefix desktop` was attempted but failed due to an environment/network restriction downloading the Electron binary (HTTP 403 `Forbidden`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04b8c63310832a9fd73189c11bc8f8)