### PR TITLE
Add centralized environment diagnostics

### DIFF
--- a/src/components/layout/DiagnosticsPanel.tsx
+++ b/src/components/layout/DiagnosticsPanel.tsx
@@ -1,5 +1,6 @@
 import { AlertTriangle, Download, Shield } from 'lucide-react';
 import { useAppState } from '../../context/AppStateContext';
+import { getCurrentEnvironmentDiagnostics } from '../../lib/environmentDiagnostics';
 import { DESKTOP_RUNTIME_UNAVAILABLE_MESSAGE, isWebRuntime } from '../../lib/runtimeEnvironment';
 
 export function DiagnosticsPanel() {
@@ -10,6 +11,7 @@ export function DiagnosticsPanel() {
   }
 
   const { snapshot, runtimeStatus } = diagnostics;
+  const environmentIssues = getCurrentEnvironmentDiagnostics();
   const safetyLogs = snapshot.logs.filter((log) => log.module === 'safety-monitor' || log.tags?.includes('safety')).slice(0, 20);
 
   return (
@@ -24,6 +26,35 @@ export function DiagnosticsPanel() {
           <div>Session: <span className="text-yellow-300">{snapshot.sessionId}</span></div>
           <div>Show: <span className="text-yellow-300">{snapshot.showId}</span></div>
           <div>MAJ: <span className="text-gray-300">{new Date(snapshot.updatedAt).toLocaleString()}</span></div>
+        </div>
+
+
+        <div className="bg-gray-900/80 rounded-lg p-3 space-y-2">
+          <div className="flex items-center justify-between gap-3">
+            <div className="font-medium">Environnement</div>
+            <span className={environmentIssues.length > 0 ? 'text-xs text-yellow-300' : 'text-xs text-emerald-300'}>
+              {environmentIssues.length > 0 ? `${environmentIssues.length} problème(s)` : 'OK'}
+            </span>
+          </div>
+          {environmentIssues.length > 0 ? (
+            <div className="space-y-2">
+              {environmentIssues.map((issue) => (
+                <div key={issue.code} className="rounded-lg border border-yellow-400/30 bg-yellow-400/10 p-3">
+                  <div className="flex items-start gap-2 text-yellow-100">
+                    <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                    <div>
+                      <div className="font-medium">{issue.title}</div>
+                      <div className="mt-1 text-xs text-yellow-50/90">{issue.message}</div>
+                      <div className="mt-2 text-xs text-gray-400">Impact: {issue.affectedFeatures.join(', ')}</div>
+                      <div className="mt-1 text-xs text-gray-300">Action: {issue.remediation}</div>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="text-xs text-gray-300">Authentification, presets cloud, version de build et runtime desktop semblent configurés.</div>
+          )}
         </div>
 
         <div className="bg-gray-900/80 rounded-lg p-3 space-y-1">

--- a/src/lib/environmentDiagnostics.ts
+++ b/src/lib/environmentDiagnostics.ts
@@ -1,0 +1,92 @@
+type EnvironmentDiagnosticSeverity = 'info' | 'warning';
+
+type EnvironmentDiagnosticFeature = 'authentication' | 'cloud-presets' | 'desktop-runtime' | 'release';
+
+export type EnvironmentDiagnosticCode =
+  | 'missing_supabase_url'
+  | 'missing_supabase_anon_key'
+  | 'desktop_runtime_unavailable'
+  | 'missing_or_dev_app_version';
+
+export interface EnvironmentDiagnosticIssue {
+  code: EnvironmentDiagnosticCode;
+  severity: EnvironmentDiagnosticSeverity;
+  title: string;
+  message: string;
+  affectedFeatures: EnvironmentDiagnosticFeature[];
+  remediation: string;
+}
+
+export interface EnvironmentDiagnosticInput {
+  supabaseUrl?: string;
+  supabaseAnonKey?: string;
+  isDesktopRuntime: boolean;
+  appVersion?: string;
+}
+
+const viteEnv = (import.meta as ImportMeta & { env?: Record<string, string | undefined> }).env ?? {};
+
+const currentEnvironment: EnvironmentDiagnosticInput = {
+  supabaseUrl: viteEnv.VITE_SUPABASE_URL,
+  supabaseAnonKey: viteEnv.VITE_SUPABASE_ANON_KEY,
+  isDesktopRuntime: typeof window !== 'undefined' && Boolean(window.lightAiNative),
+  appVersion: viteEnv.VITE_APP_VERSION,
+};
+
+const hasValue = (value: string | undefined): boolean => Boolean(value?.trim());
+
+const isDevelopmentVersion = (value: string | undefined): boolean => !hasValue(value) || value?.trim().toLowerCase() === 'dev';
+
+export const getEnvironmentDiagnostics = (
+  environment: EnvironmentDiagnosticInput = currentEnvironment,
+): EnvironmentDiagnosticIssue[] => {
+  const issues: EnvironmentDiagnosticIssue[] = [];
+
+  if (!hasValue(environment.supabaseUrl)) {
+    issues.push({
+      code: 'missing_supabase_url',
+      severity: 'warning',
+      title: 'VITE_SUPABASE_URL absent',
+      message: "L'URL Supabase n'est pas configurée, donc l'authentification et les presets cloud restent désactivés.",
+      affectedFeatures: ['authentication', 'cloud-presets'],
+      remediation: 'Définir VITE_SUPABASE_URL dans les variables Vite du build ou du fichier .env local.',
+    });
+  }
+
+  if (!hasValue(environment.supabaseAnonKey)) {
+    issues.push({
+      code: 'missing_supabase_anon_key',
+      severity: 'warning',
+      title: 'VITE_SUPABASE_ANON_KEY absent',
+      message: "La clé anonyme Supabase est absente, donc les appels d'authentification et de presets cloud ne peuvent pas démarrer.",
+      affectedFeatures: ['authentication', 'cloud-presets'],
+      remediation: 'Définir VITE_SUPABASE_ANON_KEY avec la clé publique anon du projet Supabase.',
+    });
+  }
+
+  if (!environment.isDesktopRuntime) {
+    issues.push({
+      code: 'desktop_runtime_unavailable',
+      severity: 'info',
+      title: 'Mode desktop indisponible',
+      message: "L'API native Electron n'est pas exposée dans cette session, donc le runtime desktop et les contrôles hardware sont indisponibles.",
+      affectedFeatures: ['desktop-runtime'],
+      remediation: "Lancer l'application via le shell desktop/Electron pour activer window.lightAiNative.",
+    });
+  }
+
+  if (isDevelopmentVersion(environment.appVersion)) {
+    issues.push({
+      code: 'missing_or_dev_app_version',
+      severity: 'info',
+      title: 'Version app absente ou dev',
+      message: "La version applicative n'est pas renseignée avec une valeur de release, ce qui limite le diagnostic des builds déployés.",
+      affectedFeatures: ['release'],
+      remediation: 'Définir VITE_APP_VERSION avec la version publiée pendant le build.',
+    });
+  }
+
+  return issues;
+};
+
+export const getCurrentEnvironmentDiagnostics = (): EnvironmentDiagnosticIssue[] => getEnvironmentDiagnostics();

--- a/src/lib/observability.ts
+++ b/src/lib/observability.ts
@@ -208,7 +208,8 @@ const sanitize = (value: unknown): unknown => {
   return value;
 };
 
-const APP_VERSION = import.meta.env.VITE_APP_VERSION ?? 'dev';
+const viteEnv = (import.meta as ImportMeta & { env?: Record<string, string | undefined> }).env ?? {};
+const APP_VERSION = viteEnv.VITE_APP_VERSION ?? 'dev';
 
 export const buildIncidentReport = (options: {
   exportScope: 'private' | 'public';

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -8,6 +8,7 @@ import './unit/eos-bridge.unit.test';
 import './unit/live-safety.unit.test';
 import './unit/ai-orchestrator.unit.test';
 import './unit/copilot-workspace.unit.test';
+import './unit/environment-diagnostics.unit.test';
 import './unit/safety-monitor.unit.test';
 import './contracts/ai-orchestrator.contract.test';
 import './integration/protocols.integration.test';

--- a/tests/unit/environment-diagnostics.unit.test.ts
+++ b/tests/unit/environment-diagnostics.unit.test.ts
@@ -1,0 +1,29 @@
+import { getEnvironmentDiagnostics } from '../../src/lib/environmentDiagnostics';
+import { assert, test } from '../harness';
+
+test('diagnostic environnement: signale Supabase, desktop et version dev indisponibles', () => {
+  const issues = getEnvironmentDiagnostics({
+    supabaseUrl: '',
+    supabaseAnonKey: undefined,
+    isDesktopRuntime: false,
+    appVersion: 'dev',
+  });
+
+  assert.deepEqual(issues.map((issue) => issue.code), [
+    'missing_supabase_url',
+    'missing_supabase_anon_key',
+    'desktop_runtime_unavailable',
+    'missing_or_dev_app_version',
+  ]);
+});
+
+test('diagnostic environnement: retourne une liste vide pour une configuration complète', () => {
+  const issues = getEnvironmentDiagnostics({
+    supabaseUrl: 'https://example.supabase.co',
+    supabaseAnonKey: 'anon-key',
+    isDesktopRuntime: true,
+    appVersion: '1.2.3',
+  });
+
+  assert.equal(issues.length, 0);
+});


### PR DESCRIPTION
### Motivation
- Fournir un point centralisé pour détecter et expliquer pourquoi l'authentification, les presets cloud ou le runtime desktop peuvent être indisponibles (manque de variables Vite, runtime desktop non exposé, ou version de build en `dev`).

### Description
- Ajout de `src/lib/environmentDiagnostics.ts` qui expose `getEnvironmentDiagnostics()` et `getCurrentEnvironmentDiagnostics()` et signale les codes: `missing_supabase_url`, `missing_supabase_anon_key`, `desktop_runtime_unavailable`, `missing_or_dev_app_version` avec titre, message, impact et remediation.
- Intégration des diagnostics dans le panneau existant `src/components/layout/DiagnosticsPanel.tsx` pour afficher le nombre de problèmes et, le cas échéant, leur message, impact et action de remédiation.
- Ajustement de `src/lib/observability.ts` pour lire `VITE_APP_VERSION` via un objet `viteEnv` sécurisé afin d'éviter une erreur quand `import.meta.env` est indisponible dans certains contextes de bundling/tests.
- Ajout de tests unitaires `tests/unit/environment-diagnostics.unit.test.ts` et enregistrement dans `tests/index.ts`.

### Testing
- `npx eslint src/lib/environmentDiagnostics.ts src/components/layout/DiagnosticsPanel.tsx src/lib/observability.ts tests/index.ts tests/unit/environment-diagnostics.unit.test.ts` — OK pour les fichiers modifiés (no errors on those files).
- `npm run build` — build Vite production réussi.
- Exécution ciblée des tests unitaires via un bundle Esbuild (fichier de test focalisé) — les 2 nouveaux tests unitaires passent: "diagnostic environnement: signale..." et "diagnostic environnement: retourne..." (2 test(s) passed).
- Notes: `npm run lint` sur l’ensemble du repo échoue encore à cause d’erreurs préexistantes non liées à ce changement; `npm test` complet échoue encore en environnement bundlé à cause d’une dépendance CJS de Supabase qui fait un `require('stream')` dynamique dans un contexte ESM.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04baea5c2c832aad3545bfc3fbe685)