### PR TITLE
Fix desktop dependency install on Windows

### DIFF
--- a/scripts/ensure-desktop-deps.mjs
+++ b/scripts/ensure-desktop-deps.mjs
@@ -14,11 +14,16 @@ if (existsSync(electronBin)) {
 
 console.log('Desktop dependencies are missing. Installing dependencies in ./desktop...');
 
-const npmExecutable = process.platform === 'win32' ? 'npm.cmd' : 'npm';
-const install = spawnSync(npmExecutable, ['install', '--prefix', desktopDir], {
+const npmInstallArgs = ['install', '--prefix', desktopDir];
+const npmExecPath = process.env.npm_execpath;
+const canRunNpmCliWithNode = npmExecPath?.endsWith('.js');
+const npmExecutable = canRunNpmCliWithNode ? process.execPath : 'npm';
+const npmArgs = canRunNpmCliWithNode ? [npmExecPath, ...npmInstallArgs] : npmInstallArgs;
+
+const install = spawnSync(npmExecutable, npmArgs, {
   cwd: repoRoot,
   stdio: 'inherit',
-  shell: false,
+  shell: process.platform === 'win32' && !canRunNpmCliWithNode,
 });
 
 if (install.error) {


### PR DESCRIPTION
### Motivation
- Ensure `scripts/ensure-desktop-deps.mjs` reliably installs desktop dependencies on Windows where spawning `npm.cmd` could raise `EINVAL`, by using the Node-exposed npm CLI when available.

### Description
- Replace direct `npm`/`npm.cmd` spawn with logic that checks `process.env.npm_execpath` and, when it points to a JS CLI, runs it through `process.execPath`; otherwise fall back to invoking `npm` and enable `shell` on Windows only when needed.
- Change is contained to `scripts/ensure-desktop-deps.mjs` and preserves existing exit/error handling and the electron executable check.

### Testing
- `node --check scripts/ensure-desktop-deps.mjs` completed successfully.
- `npm run desktop:check` completed successfully (build and TypeScript compile passed).
- Running `npm run predesktop:check` with `desktop/node_modules/.bin/electron` temporarily moved triggered the install path and completed successfully.
- `npm run lint` is still failing due to pre-existing unrelated lint errors in source files (automated lint step failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04d08fc74c832a9bf5539b49f6cedf)