### PR TITLE
Fix Vite CSP to support React Refresh preamble

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,10 +4,6 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta
-      http-equiv="Content-Security-Policy"
-      content="default-src 'self'; base-uri 'self'; frame-ancestors 'none'; object-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://*.supabase.co wss://*.supabase.co http://localhost:5173 ws://localhost:5173; form-action 'self'"
-    />
     <title>Vite + React + TS</title>
   </head>
   <body>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,18 +1,35 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
-const csp = [
+const commonCspDirectives = [
   "default-src 'self'",
   "base-uri 'self'",
   "frame-ancestors 'none'",
   "object-src 'none'",
-  "script-src 'self'",
   "style-src 'self' 'unsafe-inline'",
   "img-src 'self' data: https:",
   "font-src 'self' data:",
-  "connect-src 'self' https://*.supabase.co wss://*.supabase.co http://localhost:5173 ws://localhost:5173",
   "form-action 'self'"
+];
+
+const productionCsp = [
+  ...commonCspDirectives,
+  "script-src 'self'",
+  "connect-src 'self' https://*.supabase.co wss://*.supabase.co"
 ].join('; ');
+
+const devCsp = [
+  ...commonCspDirectives,
+  "script-src 'self' 'sha256-8ZgGo/nOlaDknQkDUYiedLuFRSGJwIz6LAzsOrNxhmU='",
+  "connect-src 'self' https://*.supabase.co wss://*.supabase.co http://localhost:* http://127.0.0.1:* ws:"
+].join('; ');
+
+const securityHeaders = (contentSecurityPolicy: string) => ({
+  'Content-Security-Policy': contentSecurityPolicy,
+  'Referrer-Policy': 'strict-origin-when-cross-origin',
+  'X-Content-Type-Options': 'nosniff',
+  'X-Frame-Options': 'DENY'
+});
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -21,19 +38,9 @@ export default defineConfig({
     exclude: ['lucide-react']
   },
   server: {
-    headers: {
-      'Content-Security-Policy': csp,
-      'Referrer-Policy': 'strict-origin-when-cross-origin',
-      'X-Content-Type-Options': 'nosniff',
-      'X-Frame-Options': 'DENY'
-    }
+    headers: securityHeaders(devCsp)
   },
   preview: {
-    headers: {
-      'Content-Security-Policy': csp,
-      'Referrer-Policy': 'strict-origin-when-cross-origin',
-      'X-Content-Type-Options': 'nosniff',
-      'X-Frame-Options': 'DENY'
-    }
+    headers: securityHeaders(productionCsp)
   }
 });


### PR DESCRIPTION
### Motivation
- Browsers ignore some CSP directives delivered via a `<meta>` tag and the inline React Refresh preamble was being blocked, causing `@vitejs/plugin-react` to fail detecting the preamble. This change centralizes CSP delivery and relaxes dev headers to allow the refresh preamble.

### Description
- Removed the `Content-Security-Policy` meta tag from `index.html` so unsupported directives (e.g. `frame-ancestors`) are not delivered via meta.
- Replaced the single `csp` string with shared, `productionCsp`, and `devCsp` policies in `vite.config.ts` and applied them via server headers.
- Allowed the Vite React Refresh preamble hash (`'sha256-8ZgGo/...hmU='`) and broadened dev `connect-src` to include local hosts/WebSocket URLs only in the development policy.
- Added a `securityHeaders` helper to centralize header generation and applied the dev CSP to `server` and the strict production CSP to `preview`.

### Testing
- Ran `npm run build` and the Vite production build completed successfully. (passed)
- Ran `npm run test:smoke` which runs frontend mount checks and a build, and it completed successfully. (passed)
- Ran `npm run lint` and linting failed due to preexisting TypeScript/ESLint errors in unrelated files (e.g. `src/lib/effects.ts` and several adapter files). (failed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04d3305b68832aaf7ac13298888164)