### PR TITLE
Ensure desktop dev compiles before launching Electron

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "main": "dist/main.js",
   "scripts": {
-    "dev": "electron .",
+    "dev": "npm run compile && electron .",
     "build": "npm run compile && electron-builder --config ./electron-builder.yml",
     "sign:build": "node ./scripts/sign-build.mjs",
     "build:mac": "electron-builder --mac --config ./electron-builder.yml",


### PR DESCRIPTION
### Motivation
- Ensure `desktop/dist/main.js` is produced on a clean checkout before Electron starts to avoid startup errors when running the desktop dev workflow.

### Description
- Update `desktop/package.json` `dev` script from `electron .` to `npm run compile && electron .` so the TypeScript build runs before launching Electron.

### Testing
- Ran `npm run compile --prefix desktop` which produced `desktop/dist/main.js` successfully; ran `timeout 25s npm run desktop:dev` which compiled and created `desktop/dist/main.js` before Electron started but Electron failed in this environment due to a missing system library (`libatk-1.0.so.0`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a077f973d28832aa41489ff2251c789)