### PR TITLE
docs: clarify desktop dev startup flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Dans un autre terminal, démarrez ensuite le runtime desktop Electron :
 npm run desktop:dev
 ```
 
+Cette commande compile automatiquement le runtime Electron (`desktop/`) avant de lancer la fenêtre, vous n'avez donc pas besoin d'exécuter `npm run compile --prefix desktop` séparément en usage courant.
+
 Si Windows affiche `electron n’est pas reconnu`, relancez simplement cette commande depuis la racine du dépôt : le pré-script installe `desktop/node_modules` avant d'appeler Electron. Vous pouvez aussi lancer explicitement `npm install --prefix desktop`.
 
 Par défaut, `desktop/main.ts` charge l'interface depuis :

--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -41,7 +41,7 @@ Chaque payload entrant est validé (`assertConnectDeviceRequest`, `assertSendFra
 ## Scripts
 
 Depuis la racine:
-- `npm run desktop:dev` : lance le shell desktop en mode développement.
+- `npm run desktop:dev` : compile le runtime Electron (`desktop/`), puis lance le shell desktop en mode développement.
 - `npm run desktop:build` : point d'entrée build packaging desktop.
 
 ## Évolution recommandée

--- a/docs/dev/contributing.md
+++ b/docs/dev/contributing.md
@@ -51,6 +51,8 @@ Desktop (dev):
 npm run desktop:dev
 ```
 
+`npm run desktop:dev` compile automatiquement le runtime Electron (`desktop/`) avant le lancement.
+
 ---
 
 ## 4) Tests attendus avant PR

--- a/docs/user/quickstart.md
+++ b/docs/user/quickstart.md
@@ -21,6 +21,8 @@ Pour tester le shell desktop (runtime matériel):
 npm run desktop:dev
 ```
 
+Cette commande compile automatiquement le runtime Electron (`desktop/`) avant d'ouvrir le shell desktop.
+
 ---
 
 ## 2) Connexion matériel


### PR DESCRIPTION
### Motivation
- Align documentation with the actual startup flow so developers and users know that `npm run desktop:dev` compiles the Electron runtime (`desktop/`) before launching the desktop shell.

### Description
- Updated `README.md`, `docs/architecture/runtime.md`, `docs/dev/contributing.md`, and `docs/user/quickstart.md` to confirm `npm run desktop:dev` remains the documented command and to note that it compiles the Electron runtime (`desktop/`) prior to launch, and adjusted the runtime script description accordingly.

### Testing
- Executed `npm run compile --prefix desktop`, which completed successfully.
- Executed `npm run lint`, which failed due to pre-existing unrelated lint errors in `src/lib/effects.ts` and several runtime adapter files (errors and warnings reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a078008caac832a864d91e8a70758c5)