### PR TITLE
Use electron-updater CommonJS default import

### DIFF
--- a/desktop/main.ts
+++ b/desktop/main.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import { app, BrowserWindow, dialog, session } from 'electron';
-import { autoUpdater } from 'electron-updater';
+import electronUpdater from 'electron-updater';
+const { autoUpdater } = electronUpdater;
 import { registerIpcHandlers } from './ipc/handlers.js';
 import { HardwareRuntime } from './native/hardwareRuntime.js';
 import { verifyRuntimeIntegrity } from './security/integrity.js';

--- a/desktop/release/updatePolicy.ts
+++ b/desktop/release/updatePolicy.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { autoUpdater } from 'electron-updater';
+import electronUpdater from 'electron-updater';
+const { autoUpdater } = electronUpdater;
 
 const VALID_CHANNELS = new Set(['stable', 'beta']);
 const DEFAULT_CHANNEL = 'stable';


### PR DESCRIPTION
### Motivation
- Ensure `electron-updater` is consumed through its CommonJS default export to match Electron runtime expectations and avoid module interop issues.

### Description
- Replace `import { autoUpdater } from 'electron-updater';` with `import electronUpdater from 'electron-updater'; const { autoUpdater } = electronUpdater;` in `desktop/main.ts` and `desktop/release/updatePolicy.ts`, keeping all existing `autoUpdater` event handlers, calls, and configuration unchanged.

### Testing
- Ran `npm run compile --prefix desktop`, which completed successfully.
- Ran `npm run desktop:dev`, which performed compilation but Electron failed to start due to a missing system library (`libatk-1.0.so.0`) in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a078942152c832a84a9a116c853d096)