### PR TITLE
Avoid web runtime fallback incident noise

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,7 @@ import {
 } from './lib/effectConfiguration';
 import { effects } from './lib/effects';
 import { buildIncidentReport, downloadIncidentReport, observability } from './lib/observability';
-import { runtimeClient } from './lib/runtimeClient';
+import { runtimeClient, runtimeFallbackStatus } from './lib/runtimeClient';
 import { isWebRuntime } from './lib/runtimeEnvironment';
 import { SUPABASE_DISABLED_MESSAGE, supabase } from './lib/supabase';
 import { emitAiSuggestionEvent } from './lib/aiSuggestionTelemetry';
@@ -74,15 +74,17 @@ function App() {
         .catch((error) => {
           observability.warn('runtime', 'Runtime status polling failed', {
             reason: error instanceof Error ? error.message : String(error)
-          });
+          }, ['runtime', 'ipc']);
         });
     };
 
-    pollStatus();
-
     if (isWebRuntime) {
+      setRuntimeStatus(runtimeFallbackStatus);
+      observability.debug('runtime', 'Browser/dev runtime fallback active', undefined, ['runtime', 'web']);
       return undefined;
     }
+
+    pollStatus();
 
     const id = window.setInterval(pollStatus, 1000);
     return () => clearInterval(id);

--- a/src/lib/runtimeClient.ts
+++ b/src/lib/runtimeClient.ts
@@ -12,7 +12,7 @@ import { assertRuntimeStatus as assertRuntimeStatusPayload, IPC_CONTRACT_VERSION
 import { observability } from './observability';
 import { DESKTOP_RUNTIME_UNAVAILABLE_MESSAGE, isDesktopRuntime } from './runtimeEnvironment';
 
-const fallbackStatus: RuntimeStatus = {
+export const runtimeFallbackStatus: RuntimeStatus = {
   contractVersion: EXPECTED_IPC_CONTRACT_VERSION,
   ready: false,
   connectedDeviceId: null,
@@ -27,6 +27,9 @@ const fallbackStatus: RuntimeStatus = {
 };
 
 const unavailableError = DESKTOP_RUNTIME_UNAVAILABLE_MESSAGE;
+const unavailableRuntimeTags = ['runtime', 'degraded'] as const;
+const runtimeIpcTags = ['runtime', 'ipc'] as const;
+let loggedWebRuntimeFallback = false;
 const incompatibleRuntimeErrorPrefix = 'Incompatible native runtime contract';
 
 function getNativeApi(): NativeIpcApi {
@@ -54,25 +57,42 @@ export const runtimeClient = {
   },
   getRuntimeStatus: async (): Promise<RuntimeStatusHandshake> => {
     if (!isDesktopRuntime || !window.lightAiNative) {
-      observability.warn('runtimeClient', 'Native runtime unavailable, returning fallback status', undefined, [
-        'runtime',
-        'degraded',
-      ]);
-      return { ...fallbackStatus, compatible: true };
+      if (!loggedWebRuntimeFallback) {
+        observability.info(
+          'runtimeClient',
+          'Native runtime unavailable in browser/dev mode, returning fallback status',
+          undefined,
+          [...unavailableRuntimeTags],
+        );
+        loggedWebRuntimeFallback = true;
+      }
+      return { ...runtimeFallbackStatus, compatible: true };
     }
-    const status = await window.lightAiNative.getRuntimeStatus();
-    assertRuntimeStatusPayload(status);
-    if (status.contractVersion !== EXPECTED_IPC_CONTRACT_VERSION) {
-      throw new Error(
-        `${incompatibleRuntimeErrorPrefix}: operator action required. Renderer expects ${EXPECTED_IPC_CONTRACT_VERSION}, native runtime reports ${status.contractVersion}. Restart and redeploy both desktop shell and renderer with the same build.`,
+
+    try {
+      const status = await window.lightAiNative.getRuntimeStatus();
+      assertRuntimeStatusPayload(status);
+      if (status.contractVersion !== EXPECTED_IPC_CONTRACT_VERSION) {
+        throw new Error(
+          `${incompatibleRuntimeErrorPrefix}: operator action required. Renderer expects ${EXPECTED_IPC_CONTRACT_VERSION}, native runtime reports ${status.contractVersion}. Restart and redeploy both desktop shell and renderer with the same build.`,
+        );
+      }
+      observability.setProtocolMetrics({
+        queueDepth: status.metrics.protocolQueueDepth,
+        queueHighWatermark: status.metrics.protocolQueueHighWatermark,
+        droppedFrames: status.metrics.protocolDroppedFrames,
+      });
+      return { ...status, compatible: true };
+    } catch (error) {
+      observability.error(
+        'runtimeClient',
+        'Native runtime status IPC failed',
+        { reason: error instanceof Error ? error.message : String(error) },
+        'sev2',
+        [...runtimeIpcTags],
       );
+      throw error;
     }
-    observability.setProtocolMetrics({
-      queueDepth: status.metrics.protocolQueueDepth,
-      queueHighWatermark: status.metrics.protocolQueueHighWatermark,
-      droppedFrames: status.metrics.protocolDroppedFrames,
-    });
-    return { ...status, compatible: true };
   },
   vaultSetSecret: async (request: VaultSecretRequest): Promise<void> => getNativeApi().vaultSetSecret(request),
   vaultGetSecret: async (request: VaultSecretKeyRequest): Promise<string | null> =>

--- a/tests/unit/environment-diagnostics.unit.test.ts
+++ b/tests/unit/environment-diagnostics.unit.test.ts
@@ -1,4 +1,6 @@
 import { getEnvironmentDiagnostics } from '../../src/lib/environmentDiagnostics';
+import { observability } from '../../src/lib/observability';
+import { runtimeClient } from '../../src/lib/runtimeClient';
 import { assert, test } from '../harness';
 
 test('diagnostic environnement: signale Supabase, desktop et version dev indisponibles', () => {
@@ -26,4 +28,33 @@ test('diagnostic environnement: retourne une liste vide pour une configuration c
   });
 
   assert.equal(issues.length, 0);
+});
+
+test('diagnostic runtime: le fallback web ne crée pas de warnings sev3 répétés', async () => {
+  const countWebFallbackIncidents = () =>
+    observability
+      .snapshot()
+      .logs.filter(
+        (entry) =>
+          entry.module === 'runtimeClient' &&
+          entry.message.includes('Native runtime unavailable') &&
+          entry.incidentSeverity === 'sev3',
+      ).length;
+
+  const before = countWebFallbackIncidents();
+
+  await runtimeClient.getRuntimeStatus();
+  await runtimeClient.getRuntimeStatus();
+
+  const fallbackLogs = observability
+    .snapshot()
+    .logs.filter(
+      (entry) =>
+        entry.module === 'runtimeClient' && entry.message.includes('Native runtime unavailable in browser/dev mode'),
+    );
+
+  assert.equal(countWebFallbackIncidents(), before);
+  assert.equal(fallbackLogs.length, 1);
+  assert.equal(fallbackLogs[0].level, 'info');
+  assert.equal(fallbackLogs[0].incidentSeverity, 'none');
 });


### PR DESCRIPTION
### Motivation
- Prevent browser/dev (web) runtime from generating repeated sev3 incident warnings that pollute exported incident reports.
- Ensure real desktop IPC failures still surface with appropriate severity and `runtime`/`ipc` tags.

### Description
- Skip calling the native IPC `getRuntimeStatus()` in the web runtime and initialize UI state from an exported `runtimeFallbackStatus` instead (`src/App.tsx`, `src/lib/runtimeClient.ts`).
- Downgrade the expected missing-native runtime fallback to a once-per-session non-incident/info log and mark it with `['runtime','degraded']`; true IPC failures are caught and logged as `error` with `sev2` and `['runtime','ipc']` tags (`src/lib/runtimeClient.ts`).
- Update the app polling effect to set the fallback status immediately when `isWebRuntime` and to avoid the periodic poll in that mode (`src/App.tsx`).
- Add unit test coverage asserting the web fallback does not create repeated `sev3` warnings and that the fallback log is a single `info`/non-incident entry (`tests/unit/environment-diagnostics.unit.test.ts`).

### Testing
- Built the frontend with `npm run build` which completed successfully. 
- Executed the targeted unit diagnostics bundle (esbuild+node) which ran the environment diagnostics tests and the new runtime fallback test and reported `3 test(s) passed.`
- Running the full test harness via `npm test` failed due to the test bundler hitting a `Dynamic require of "stream"` from the Supabase dependency in the current Node/esbuild environment, unrelated to these changes. 
- Linting via `npm run lint` reports pre-existing lint issues in unrelated files; no new lint errors were introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a078ad30cac832a9aa62f0bf91b00ce)