### PR TITLE
Initialize main show observability before profile hooks

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -16,6 +16,7 @@ try {
     sourcemap: 'inline',
     outfile: outputFile,
     logLevel: 'silent',
+    banner: { js: "import { createRequire } from 'node:module'; const require = createRequire(import.meta.url);" },
   });
 
   await import(pathToFileURL(outputFile).href);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,12 +19,19 @@ import {
   rollbackConfiguration
 } from './lib/effectConfiguration';
 import { effects } from './lib/effects';
-import { buildIncidentReport, downloadIncidentReport, observability } from './lib/observability';
+import {
+  buildIncidentReport,
+  downloadIncidentReport,
+  initializeMainShowObservability,
+  observability
+} from './lib/observability';
 import { runtimeClient, runtimeFallbackStatus } from './lib/runtimeClient';
 import { isWebRuntime } from './lib/runtimeEnvironment';
 import { SUPABASE_DISABLED_MESSAGE, supabase } from './lib/supabase';
 import { emitAiSuggestionEvent } from './lib/aiSuggestionTelemetry';
 import type { CollaborationConflict, GuidedMergeResolution } from './lib/collaborationStrategy';
+
+initializeMainShowObservability();
 
 function App() {
   const [activeConflict, setActiveConflict] = useState<CollaborationConflict<Record<string, unknown>> | null>(null);
@@ -55,7 +62,6 @@ function App() {
 
 
   useEffect(() => {
-    observability.setShowId('main-show');
     observability.info('app', 'Application booted');
   }, []);
 

--- a/src/hooks/useSupabaseProfile.ts
+++ b/src/hooks/useSupabaseProfile.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
-import { SUPABASE_DISABLED_MESSAGE, supabase, type Profile } from '../lib/supabase';
+import { supabase, type Profile } from '../lib/supabase';
 import { observability } from '../lib/observability';
+import { logSupabaseDisabledOnce } from '../lib/supabaseDiagnostics';
 
 export function useSupabaseProfile() {
   const [profile, setProfile] = useState<Profile | null>(null);
@@ -8,7 +9,7 @@ export function useSupabaseProfile() {
 
   const fetchProfile = useCallback(async (userId: string) => {
     if (!supabase) {
-      observability.warn('useSupabaseProfile', SUPABASE_DISABLED_MESSAGE, { userId }, ['auth', 'configuration']);
+      logSupabaseDisabledOnce({ userId });
       return;
     }
 
@@ -32,7 +33,7 @@ export function useSupabaseProfile() {
 
   useEffect(() => {
     if (!supabase) {
-      observability.warn('useSupabaseProfile', SUPABASE_DISABLED_MESSAGE, undefined, ['auth', 'configuration']);
+      logSupabaseDisabledOnce();
       setProfile(null);
       return;
     }

--- a/src/lib/observability.ts
+++ b/src/lib/observability.ts
@@ -40,6 +40,7 @@ export interface ObservabilitySnapshot {
 
 const LOG_LIMIT = 400;
 const LATENCY_SAMPLE_LIMIT = 240;
+const MAIN_SHOW_ID = 'main-show';
 
 const randomId = (): string =>
   typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
@@ -67,9 +68,26 @@ class ObservabilityStore {
   private protocolQueueHighWatermark = 0;
   private protocolDroppedFrames = 0;
   private incidentTimeline: IncidentTimelineEvent[] = [];
+  private emittedOnceKeys = new Set<string>();
 
   setShowId(showId: string): void {
     this.showId = showId;
+  }
+
+  logOnce(
+    key: string,
+    level: ObservabilityLevel,
+    module: string,
+    message: string,
+    data?: Record<string, unknown>,
+    options?: { tags?: string[]; incidentSeverity?: 'sev1' | 'sev2' | 'sev3' | 'none' }
+  ): void {
+    if (this.emittedOnceKeys.has(key)) {
+      return;
+    }
+
+    this.emittedOnceKeys.add(key);
+    this.log(level, module, message, data, options);
   }
 
   log(
@@ -160,6 +178,10 @@ class ObservabilityStore {
 
 const store = new ObservabilityStore();
 
+export const initializeMainShowObservability = (): void => {
+  store.setShowId(MAIN_SHOW_ID);
+};
+
 export const observability = {
   setShowId: (showId: string) => store.setShowId(showId),
   debug: (module: string, message: string, data?: Record<string, unknown>, tags?: string[]) =>
@@ -168,6 +190,8 @@ export const observability = {
     store.log('info', module, message, data, { tags, incidentSeverity: 'none' }),
   warn: (module: string, message: string, data?: Record<string, unknown>, tags?: string[]) =>
     store.log('warn', module, message, data, { tags, incidentSeverity: 'sev3' }),
+  warnOnce: (key: string, module: string, message: string, data?: Record<string, unknown>, tags?: string[]) =>
+    store.logOnce(key, 'warn', module, message, data, { tags, incidentSeverity: 'sev3' }),
   error: (
     module: string,
     message: string,

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,9 +1,11 @@
 import { createClient } from '@supabase/supabase-js';
+import { SUPABASE_DISABLED_MESSAGE } from './supabaseStatus';
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+const viteEnv = (import.meta as ImportMeta & { env?: Record<string, string | undefined> }).env ?? {};
+const supabaseUrl = viteEnv.VITE_SUPABASE_URL;
+const supabaseAnonKey = viteEnv.VITE_SUPABASE_ANON_KEY;
 
-export const SUPABASE_DISABLED_MESSAGE = 'Supabase is not configured. Authentication and cloud presets are disabled.';
+export { SUPABASE_DISABLED_MESSAGE };
 
 export const isSupabaseConfigured = Boolean(supabaseUrl && supabaseAnonKey);
 

--- a/src/lib/supabaseDiagnostics.ts
+++ b/src/lib/supabaseDiagnostics.ts
@@ -1,0 +1,14 @@
+import { observability } from './observability';
+import { SUPABASE_DISABLED_MESSAGE } from './supabaseStatus';
+
+const SUPABASE_DISABLED_LOG_KEY = 'useSupabaseProfile:supabase-disabled';
+
+export function logSupabaseDisabledOnce(data?: Record<string, unknown>) {
+  observability.warnOnce(
+    SUPABASE_DISABLED_LOG_KEY,
+    'useSupabaseProfile',
+    SUPABASE_DISABLED_MESSAGE,
+    data,
+    ['auth', 'configuration'],
+  );
+}

--- a/src/lib/supabaseStatus.ts
+++ b/src/lib/supabaseStatus.ts
@@ -1,0 +1,1 @@
+export const SUPABASE_DISABLED_MESSAGE = 'Supabase is not configured. Authentication and cloud presets are disabled.';

--- a/tests/unit/environment-diagnostics.unit.test.ts
+++ b/tests/unit/environment-diagnostics.unit.test.ts
@@ -1,5 +1,7 @@
 import { getEnvironmentDiagnostics } from '../../src/lib/environmentDiagnostics';
-import { observability } from '../../src/lib/observability';
+import { initializeMainShowObservability, observability } from '../../src/lib/observability';
+import { logSupabaseDisabledOnce } from '../../src/lib/supabaseDiagnostics';
+import { SUPABASE_DISABLED_MESSAGE } from '../../src/lib/supabaseStatus';
 import { runtimeClient } from '../../src/lib/runtimeClient';
 import { assert, test } from '../harness';
 
@@ -57,4 +59,20 @@ test('diagnostic runtime: le fallback web ne crée pas de warnings sev3 répét�
   assert.equal(fallbackLogs.length, 1);
   assert.equal(fallbackLogs[0].level, 'info');
   assert.equal(fallbackLogs[0].incidentSeverity, 'none');
+});
+
+test('diagnostic Supabase désactivé: les logs sont attribués au show principal avant les hooks', () => {
+  initializeMainShowObservability();
+  const existingIds = new Set(observability.snapshot().logs.map((entry) => entry.id));
+
+  logSupabaseDisabledOnce();
+  logSupabaseDisabledOnce();
+
+  const supabaseDisabledLogs = observability
+    .snapshot()
+    .logs.filter((entry) => !existingIds.has(entry.id) && entry.message === SUPABASE_DISABLED_MESSAGE);
+
+  assert.equal(supabaseDisabledLogs.length, 1);
+  assert.equal(supabaseDisabledLogs[0].module, 'useSupabaseProfile');
+  assert.equal(supabaseDisabledLogs[0].showId, 'main-show');
 });


### PR DESCRIPTION
### Motivation
- Hook-level diagnostics emitted during React mount were being attributed to the default show because `observability.setShowId` was set inside an effect, which can run after hooks under `StrictMode`.
- Prevent duplicated, expected Supabase-missing warnings caused by double-mounting under `StrictMode` by providing a one-shot logging API.
- Make the test runner and Supabase environment access robust outside Vite so unit tests can exercise diagnostics deterministically.

### Description
- Initialize `main-show` at module/app bootstrap by calling `initializeMainShowObservability()` from `src/App.tsx` before `useSupabaseProfile()` is invoked, and keep the `Application booted` info log in the effect (moved `setShowId` out of the effect). 
- Add one-shot emission support to observability (`logOnce`/`warnOnce`) and an `initializeMainShowObservability` helper in `src/lib/observability.ts` to set the default show id early. 
- Introduce a small diagnostics helper `logSupabaseDisabledOnce` in `src/lib/supabaseDiagnostics.ts` and centralize the Supabase-disabled message into `src/lib/supabaseStatus.ts`; update `useSupabaseProfile()` to call the one-shot helper for both fetch-time and effect-time missing-config paths. 
- Make Supabase env access resilient outside Vite by reading `import.meta.env` safely in `src/lib/supabase.ts`, and add a test helper change to the bundler in `scripts/run-tests.mjs` so bundled CommonJS deps can resolve Node built-ins. 
- Add/update a unit test in `tests/unit/environment-diagnostics.unit.test.ts` to assert that Supabase-disabled logs are attributed to `main-show` and emitted only once.

### Testing
- Ran `npm test`: the new Supabase-disabled diagnostics test passes, but the full suite fails due to two unrelated existing time-sync assertions (`Time sync: lock, perte source, reprise et diagnostics` and `Time sync: cohérence cues déclenchées pendant lock/degraded`).
- Ran `npm run lint`: linting still reports pre-existing issues (errors in `src/lib/effects.ts` and unused params in runtime adapters) and warnings unrelated to this change.
- Ran `npm run build`: build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a078e456950832a905a092cb2c982bd)