### PR TITLE
Ensure runtime status fallback matches RuntimeStatus contract

### DIFF
--- a/desktop/ipc/contracts.ts
+++ b/desktop/ipc/contracts.ts
@@ -137,6 +137,9 @@ export function assertRuntimeStatus(value: unknown): asserts value is RuntimeSta
   if (typeof value.dryRun !== 'boolean') {
     throw new Error('Invalid runtime status payload: missing dryRun flag.');
   }
+  if (!(value.deviceStatus === null || isRecord(value.deviceStatus))) {
+    throw new Error('Invalid runtime status payload: invalid deviceStatus.');
+  }
   if (!isRecord(value.metrics)) {
     throw new Error('Invalid runtime status payload: missing metrics.');
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { PlayerBar } from './components/layout/PlayerBar';
 import { ConflictResolutionPanel } from './components/ConflictResolutionPanel';
 import { CopilotWorkspace } from './features/copilot/CopilotWorkspace';
 import { AppStateProvider } from './context/AppStateContext';
+import type { AppStateValue } from './context/AppStateTypes';
 import { usePlaybackState } from './hooks/usePlaybackState';
 import { useSupabaseProfile } from './hooks/useSupabaseProfile';
 import {
@@ -25,11 +26,12 @@ import {
   initializeMainShowObservability,
   observability
 } from './lib/observability';
-import { runtimeClient, runtimeFallbackStatus } from './lib/runtimeClient';
+import { cloneRuntimeStatus, createRuntimeFallbackStatus, runtimeClient } from './lib/runtimeClient';
 import { isWebRuntime } from './lib/runtimeEnvironment';
 import { SUPABASE_DISABLED_MESSAGE, supabase } from './lib/supabase';
 import { emitAiSuggestionEvent } from './lib/aiSuggestionTelemetry';
 import type { CollaborationConflict, GuidedMergeResolution } from './lib/collaborationStrategy';
+import type { RuntimeStatus } from '../desktop/ipc/contracts';
 
 initializeMainShowObservability();
 
@@ -38,16 +40,7 @@ function App() {
   const [showVirtualStage, setShowVirtualStage] = useState(false);
   const [showEffectPanel, setShowEffectPanel] = useState(false);
   const [showDiagnostics, setShowDiagnostics] = useState(false);
-  const [runtimeStatus, setRuntimeStatus] = useState(() => ({
-    ready: false,
-    connectedDeviceId: null,
-    protocol: null,
-    metrics: {
-      protocolQueueDepth: 0,
-      protocolQueueHighWatermark: 0,
-      protocolDroppedFrames: 0
-    }
-  }));
+  const [runtimeStatus, setRuntimeStatus] = useState<RuntimeStatus>(createRuntimeFallbackStatus);
   const profileState = useSupabaseProfile();
 
   const telemetryContext = useMemo(() => ({
@@ -70,7 +63,7 @@ function App() {
       runtimeClient
         .getRuntimeStatus()
         .then((status) => {
-          setRuntimeStatus(status);
+          setRuntimeStatus(cloneRuntimeStatus(status));
           observability.setProtocolMetrics({
             queueDepth: status.metrics.protocolQueueDepth,
             queueHighWatermark: status.metrics.protocolQueueHighWatermark,
@@ -85,7 +78,7 @@ function App() {
     };
 
     if (isWebRuntime) {
-      setRuntimeStatus(runtimeFallbackStatus);
+      setRuntimeStatus(createRuntimeFallbackStatus());
       observability.debug('runtime', 'Browser/dev runtime fallback active', undefined, ['runtime', 'web']);
       return undefined;
     }
@@ -332,7 +325,7 @@ function App() {
     [playbackState.currentEffect, playbackState.isMuted, playbackState.volume, profileState.profile, runtimeStatus, showEffectPanel, showVirtualStage]
   );
 
-  const appState = useMemo(
+  const appState = useMemo<AppStateValue>(
     () => ({
       profile: profileState.profile,
       isAuthModalOpen: profileState.isAuthModalOpen,

--- a/src/context/AppStateContext.tsx
+++ b/src/context/AppStateContext.tsx
@@ -1,47 +1,5 @@
 import { createContext, useContext, type ReactNode } from 'react';
-import type { RuntimeStatus } from '../../desktop/ipc/contracts';
-import type { ObservabilitySnapshot } from '../lib/observability';
-import type { Profile } from '../lib/supabase';
-
-interface PlaybackState {
-  isPlaying: boolean;
-  currentEffect: number;
-  currentTime: number;
-  volume: number;
-  isMuted: boolean;
-  togglePlay: () => void;
-  increaseVolume: () => void;
-  decreaseVolume: () => void;
-  toggleMute: () => void;
-}
-
-interface VirtualStageState {
-  showVirtualStage: boolean;
-  toggleVirtualStage: () => void;
-  presets: string[];
-  activePreset: number;
-  nextPreset: () => void;
-}
-
-interface DiagnosticsState {
-  isOpen: boolean;
-  toggle: () => void;
-  snapshot: ObservabilitySnapshot;
-  runtimeStatus: RuntimeStatus;
-  exportIncidentReport: (scope: 'private' | 'public') => void;
-}
-
-interface AppStateValue {
-  profile: Profile | null;
-  isAuthModalOpen: boolean;
-  openAuthModal: () => void;
-  closeAuthModal: () => void;
-  showEffectPanel: boolean;
-  toggleEffectPanel: () => void;
-  playback: PlaybackState;
-  virtualStage: VirtualStageState;
-  diagnostics: DiagnosticsState;
-}
+import type { AppStateValue } from './AppStateTypes';
 
 const AppStateContext = createContext<AppStateValue | null>(null);
 

--- a/src/context/AppStateTypes.ts
+++ b/src/context/AppStateTypes.ts
@@ -1,0 +1,43 @@
+import type { RuntimeStatus } from '../../desktop/ipc/contracts';
+import type { ObservabilitySnapshot } from '../lib/observability';
+import type { Profile } from '../lib/supabase';
+
+export interface PlaybackState {
+  isPlaying: boolean;
+  currentEffect: number;
+  currentTime: number;
+  volume: number;
+  isMuted: boolean;
+  togglePlay: () => void;
+  increaseVolume: () => void;
+  decreaseVolume: () => void;
+  toggleMute: () => void;
+}
+
+export interface VirtualStageState {
+  showVirtualStage: boolean;
+  toggleVirtualStage: () => void;
+  presets: string[];
+  activePreset: number;
+  nextPreset: () => void;
+}
+
+export interface DiagnosticsState {
+  isOpen: boolean;
+  toggle: () => void;
+  snapshot: ObservabilitySnapshot;
+  runtimeStatus: RuntimeStatus;
+  exportIncidentReport: (scope: 'private' | 'public') => void;
+}
+
+export interface AppStateValue {
+  profile: Profile | null;
+  isAuthModalOpen: boolean;
+  openAuthModal: () => void;
+  closeAuthModal: () => void;
+  showEffectPanel: boolean;
+  toggleEffectPanel: () => void;
+  playback: PlaybackState;
+  virtualStage: VirtualStageState;
+  diagnostics: DiagnosticsState;
+}

--- a/src/lib/observability.ts
+++ b/src/lib/observability.ts
@@ -1,3 +1,5 @@
+import type { RuntimeStatus } from '../../desktop/ipc/contracts';
+
 export type ObservabilityLevel = 'debug' | 'info' | 'warn' | 'error';
 
 export interface ObservabilityLogEntry {
@@ -237,7 +239,7 @@ const APP_VERSION = viteEnv.VITE_APP_VERSION ?? 'dev';
 
 export const buildIncidentReport = (options: {
   exportScope: 'private' | 'public';
-  runtimeStatus: unknown;
+  runtimeStatus: RuntimeStatus;
   appConfig: Record<string, unknown>;
 }): string => {
   const snapshot = observability.snapshot();

--- a/src/lib/runtimeClient.ts
+++ b/src/lib/runtimeClient.ts
@@ -12,7 +12,7 @@ import { assertRuntimeStatus as assertRuntimeStatusPayload, IPC_CONTRACT_VERSION
 import { observability } from './observability';
 import { DESKTOP_RUNTIME_UNAVAILABLE_MESSAGE, isDesktopRuntime } from './runtimeEnvironment';
 
-export const runtimeFallbackStatus: RuntimeStatus = {
+export const runtimeFallbackStatus: Readonly<RuntimeStatus> = {
   contractVersion: EXPECTED_IPC_CONTRACT_VERSION,
   ready: false,
   connectedDeviceId: null,
@@ -25,6 +25,25 @@ export const runtimeFallbackStatus: RuntimeStatus = {
     protocolDroppedFrames: 0
   }
 };
+
+export const cloneRuntimeStatus = (status: RuntimeStatus): RuntimeStatus => ({
+  contractVersion: status.contractVersion,
+  ready: status.ready,
+  connectedDeviceId: status.connectedDeviceId,
+  protocol: status.protocol,
+  dryRun: status.dryRun,
+  deviceStatus: status.deviceStatus
+    ? {
+        ...status.deviceStatus,
+        recentErrors: [...status.deviceStatus.recentErrors],
+        reconnect: { ...status.deviceStatus.reconnect },
+        circuitBreaker: { ...status.deviceStatus.circuitBreaker }
+      }
+    : null,
+  metrics: { ...status.metrics }
+});
+
+export const createRuntimeFallbackStatus = (): RuntimeStatus => cloneRuntimeStatus(runtimeFallbackStatus);
 
 const unavailableError = DESKTOP_RUNTIME_UNAVAILABLE_MESSAGE;
 const unavailableRuntimeTags = ['runtime', 'degraded'] as const;
@@ -66,7 +85,7 @@ export const runtimeClient = {
         );
         loggedWebRuntimeFallback = true;
       }
-      return { ...runtimeFallbackStatus, compatible: true };
+      return { ...createRuntimeFallbackStatus(), compatible: true };
     }
 
     try {

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -9,6 +9,7 @@ import './unit/live-safety.unit.test';
 import './unit/ai-orchestrator.unit.test';
 import './unit/copilot-workspace.unit.test';
 import './unit/environment-diagnostics.unit.test';
+import './unit/runtime-status.unit.test';
 import './unit/safety-monitor.unit.test';
 import './contracts/ai-orchestrator.contract.test';
 import './integration/protocols.integration.test';

--- a/tests/integration/protocols.integration.test.ts
+++ b/tests/integration/protocols.integration.test.ts
@@ -134,6 +134,18 @@ test('IPC payloads invalides/champs manquants sont rejetés', async () => {
   assert.throws(() => assertConnectDeviceRequest({}), /Invalid connect device payload/);
   assert.throws(() => assertSendFrameRequest({ universe: 0 }), /channelValues/);
   assert.throws(() => assertRuntimeStatus({ ready: true }), /contractVersion/);
+  assert.throws(
+    () =>
+      assertRuntimeStatus({
+        contractVersion: IPC_CONTRACT_VERSION,
+        ready: false,
+        connectedDeviceId: null,
+        protocol: null,
+        dryRun: true,
+        metrics: { protocolQueueDepth: 0, protocolQueueHighWatermark: 0, protocolDroppedFrames: 0 },
+      }),
+    /deviceStatus/,
+  );
 });
 
 test('IPC payload extrême DMX est accepté (512 canaux)', async () => {
@@ -169,5 +181,5 @@ test('Snapshot schéma: SendFrameRequest', async () => {
 test('Snapshot schéma: RuntimeStatus', async () => {
   const snapshot = JSON.parse(readFileSync(join(process.cwd(), 'tests/snapshots/runtime-status.schema.json'), 'utf8'));
   assert.equal(snapshot.properties.contractVersion.const, IPC_CONTRACT_VERSION);
-  assert.deepEqual(snapshot.required.slice(0, 2), ['contractVersion', 'ready']);
+  assert.deepEqual(snapshot.required, ['contractVersion', 'ready', 'connectedDeviceId', 'protocol', 'dryRun', 'deviceStatus', 'metrics']);
 });

--- a/tests/snapshots/runtime-status.schema.json
+++ b/tests/snapshots/runtime-status.schema.json
@@ -1,12 +1,13 @@
 {
   "type": "object",
-  "required": ["contractVersion", "ready", "connectedDeviceId", "protocol", "dryRun", "metrics"],
+  "required": ["contractVersion", "ready", "connectedDeviceId", "protocol", "dryRun", "deviceStatus", "metrics"],
   "properties": {
     "contractVersion": { "type": "string", "const": "1.1.0" },
     "ready": { "type": "boolean" },
     "connectedDeviceId": { "type": ["string", "null"] },
     "protocol": { "type": ["string", "null"], "enum": ["dmx", "artnet", "osc", null] },
     "dryRun": { "type": "boolean" },
+    "deviceStatus": { "type": ["object", "null"] },
     "metrics": {
       "type": "object",
       "required": ["protocolQueueDepth", "protocolQueueHighWatermark", "protocolDroppedFrames"]

--- a/tests/unit/runtime-status.unit.test.ts
+++ b/tests/unit/runtime-status.unit.test.ts
@@ -1,0 +1,85 @@
+import { IPC_CONTRACT_VERSION, assertRuntimeStatus } from '../../desktop/ipc/contracts';
+import { buildIncidentReport } from '../../src/lib/observability';
+import { cloneRuntimeStatus, createRuntimeFallbackStatus, runtimeClient, runtimeFallbackStatus } from '../../src/lib/runtimeClient';
+import { assert, test } from '../harness';
+
+test('runtime fallback: shared initial status satisfies the RuntimeStatus contract', () => {
+  assert.doesNotThrow(() => assertRuntimeStatus(runtimeFallbackStatus));
+  assert.equal(runtimeFallbackStatus.contractVersion, IPC_CONTRACT_VERSION);
+  assert.equal(runtimeFallbackStatus.ready, false);
+  assert.equal(runtimeFallbackStatus.connectedDeviceId, null);
+  assert.equal(runtimeFallbackStatus.protocol, null);
+  assert.equal(runtimeFallbackStatus.dryRun, true);
+  assert.equal(runtimeFallbackStatus.deviceStatus, null);
+  assert.deepEqual(runtimeFallbackStatus.metrics, {
+    protocolQueueDepth: 0,
+    protocolQueueHighWatermark: 0,
+    protocolDroppedFrames: 0,
+  });
+});
+
+test('runtime fallback: factory returns complete independent RuntimeStatus objects for AppStateContext', () => {
+  const first = createRuntimeFallbackStatus();
+  const second = createRuntimeFallbackStatus();
+
+  assert.doesNotThrow(() => assertRuntimeStatus(first));
+  assert.doesNotThrow(() => assertRuntimeStatus(second));
+  assert.notEqual(first, second);
+  assert.notEqual(first.metrics, second.metrics);
+});
+
+test('runtime client polling returns the same complete fallback shape in web mode', async () => {
+  const status = await runtimeClient.getRuntimeStatus();
+
+  assert.doesNotThrow(() => assertRuntimeStatus(status));
+  assert.equal(status.compatible, true);
+  assert.deepEqual(Object.keys(status).sort(), [
+    'compatible',
+    'connectedDeviceId',
+    'contractVersion',
+    'deviceStatus',
+    'dryRun',
+    'metrics',
+    'protocol',
+    'ready',
+  ]);
+});
+
+test('incident export receives complete runtime status before polling', () => {
+  const report = JSON.parse(buildIncidentReport({
+    exportScope: 'private',
+    runtimeStatus: createRuntimeFallbackStatus(),
+    appConfig: {},
+  }));
+
+  assert.doesNotThrow(() => assertRuntimeStatus(report.runtimeStatus));
+  assert.deepEqual(Object.keys(report.runtimeStatus).sort(), [
+    'connectedDeviceId',
+    'contractVersion',
+    'deviceStatus',
+    'dryRun',
+    'metrics',
+    'protocol',
+    'ready',
+  ]);
+});
+
+test('incident export receives complete runtime status after runtime polling', async () => {
+  const status = cloneRuntimeStatus(await runtimeClient.getRuntimeStatus());
+  const report = JSON.parse(buildIncidentReport({
+    exportScope: 'private',
+    runtimeStatus: status,
+    appConfig: {},
+  }));
+
+  assert.doesNotThrow(() => assertRuntimeStatus(report.runtimeStatus));
+  assert.deepEqual(Object.keys(report.runtimeStatus).sort(), [
+    'connectedDeviceId',
+    'contractVersion',
+    'deviceStatus',
+    'dryRun',
+    'metrics',
+    'protocol',
+    'ready',
+  ]);
+});


### PR DESCRIPTION
### Motivation
- Ensure the initial runtime status held in the React app exactly matches the `RuntimeStatus` IPC contract so downstream consumers (AppStateContext, diagnostics, incident exports) never receive incomplete shapes. 
- Reuse a single canonical fallback/clone to avoid ad-hoc partial objects being placed into state before the native runtime is polled. 
- Tighten contract validation and snapshot tests to catch regressions where `deviceStatus` or metrics fields are missing. 

### Description
- Added a shared, typed fallback and helpers in `src/lib/runtimeClient.ts`: a `runtimeFallbackStatus: Readonly<RuntimeStatus>`, a `cloneRuntimeStatus(status: RuntimeStatus)` helper, and `createRuntimeFallbackStatus()` factory so callers get independent, contract-complete objects. 
- Replaced App ad-hoc initializer with the canonical factory and normalized polled payloads by cloning before storing in state in `src/App.tsx` so `AppStateContext` always exposes a `RuntimeStatus`-complete object. 
- Pulled `AppState` type definitions into `src/context/AppStateTypes.ts` and updated `src/context/AppStateContext.tsx` so `diagnostics.runtimeStatus` is statically `RuntimeStatus`. 
- Typed incident export to accept a `RuntimeStatus` in `src/lib/observability.ts` and tightened IPC contract validation in `desktop/ipc/contracts.ts` to assert `deviceStatus` shape. 
- Added/updated tests and schema snapshot: new unit `tests/unit/runtime-status.unit.test.ts`, updated `tests/snapshots/runtime-status.schema.json`, and updated the protocol integration snapshot assertion in `tests/integration/protocols.integration.test.ts` to include `deviceStatus`. 

### Testing
- Built the app with `npm run build` which completed successfully. 
- Ran targeted runtime-status unit checks via an esbuild test harness and the new `tests/unit/runtime-status.unit.test.ts` which passed (3+ targeted assertions plus polling/incident export checks). 
- Ran the targeted `tests/integration/protocols.integration.test.ts` bundle which passed for protocol-related assertions. 
- Ran full test suite `npm test` where unrelated existing time-sync tests failed (two assertions) and caused overall test-run failures; the runtime-status and protocol checks introduced by this change passed. 
- `npm run lint` and `npx tsc -p tsconfig.app.json --noEmit` revealed pre-existing lint/type issues elsewhere in the repo that were not introduced by this change and remain to be addressed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b0f01bd34832abaf1dc1cbc40c2e3)