### PR TITLE
Bump IPC contract version to 1.2.0

### DIFF
--- a/desktop/ipc/contracts.ts
+++ b/desktop/ipc/contracts.ts
@@ -9,7 +9,7 @@ export const ipcChannels = {
   vaultDeleteSecret: 'security:vault:delete-secret'
 } as const;
 
-export const IPC_CONTRACT_VERSION = '1.1.0' as const;
+export const IPC_CONTRACT_VERSION = '1.2.0' as const;
 
 export type IpcChannel = (typeof ipcChannels)[keyof typeof ipcChannels];
 

--- a/docs/architecture/ipc-contract-migrations.md
+++ b/docs/architecture/ipc-contract-migrations.md
@@ -1,5 +1,9 @@
 # IPC Contract Migrations
 
+## 1.2.0 — 2026-05-18
+- Added runtime status validation for nullable `deviceStatus` payloads so handshake responses reject malformed device status objects.
+- Preserved the existing `RuntimeStatus` payload shape, keeping the change backward-compatible for valid renderer and desktop shell clients.
+
 ## 1.1.0 — 2026-04-30
 - Added `contractVersion` to `RuntimeStatus` payload.
 - Added startup handshake check on `runtime:status` in renderer runtime client.


### PR DESCRIPTION
### Motivation
- The IPC contract introduced stricter validation around the `deviceStatus` field in `RuntimeStatus`, requiring an explicit nullable-record check to reject malformed handshake responses. 
- The contract version must be bumped and documented so renderer and desktop shell deployments can detect and coordinate on the change.

### Description
- Updated `IPC_CONTRACT_VERSION` from `1.1.0` to `1.2.0` in `desktop/ipc/contracts.ts`.
- Added a top-level `## 1.2.0 — 2026-05-18` entry to `docs/architecture/ipc-contract-migrations.md` describing the change. 
- The migration note documents the addition of runtime status validation for nullable `deviceStatus` and clarifies the change is backward-compatible for valid clients.

### Testing
- Ran `node scripts/check-ipc-contract-governance.mjs` before the edits which failed due to the contract changing without a version bump. 
- Re-ran `node scripts/check-ipc-contract-governance.mjs` after adding the version bump and migration note, and the governance check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b1eeb220c832aabd96f6e8eaade0d)