### PR TITLE
Fix unused effect analyzer parameters

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,6 +19,10 @@ export default tseslint.config(
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+      ],
       'react-refresh/only-export-components': [
         'warn',
         { allowConstantExport: true },

--- a/src/lib/effects.ts
+++ b/src/lib/effects.ts
@@ -3,7 +3,7 @@ import { AudioAnalyzer, type EnergyBands } from '../core/audio';
 export interface Effect {
   name: string;
   color: string;
-  configuration: Record<string, any>;
+  configuration: Record<string, unknown>;
   render: (ctx: CanvasRenderingContext2D, canvas: HTMLCanvasElement, analyzer?: AudioAnalyzer) => void;
 }
 
@@ -43,7 +43,7 @@ const createGradient = (ctx: CanvasRenderingContext2D, colors: string[]) => {
   return gradient;
 };
 
-export const effects: Effect[] = [
+export const effects = [
   {
     name: 'Color Chase',
     color: '#FFD700',
@@ -158,7 +158,7 @@ export const effects: Effect[] = [
       maxSpeed: 2,
       connectionRadius: 100
     },
-    render: (ctx, canvas, analyzer) => {
+    render: (ctx, canvas) => {
       const { particleCount, maxSpeed, connectionRadius } = effects[3].configuration;
       
       interface Particle {
@@ -220,7 +220,7 @@ export const effects: Effect[] = [
       rotationSpeed: 1,
       thickness: 2
     },
-    render: (ctx, canvas, analyzer) => {
+    render: (ctx, canvas) => {
       const { beamCount, rotationSpeed, thickness } = effects[4].configuration;
       const time = Date.now() * 0.001 * rotationSpeed;
 
@@ -262,4 +262,4 @@ export const effects: Effect[] = [
       }
     }
   }
-];
+] satisfies Effect[];


### PR DESCRIPTION
### Motivation
- Remove unused `analyzer` parameters from effect render callbacks that are not audio-reactive to eliminate lint errors and clarify intent.
- Preserve the `Effect.render` signature so genuinely audio-reactive effects can still receive an optional `AudioAnalyzer`.

### Description
- Removed the third `analyzer` parameter from the `Particle System` and `Laser Show` `render` arrow function signatures in `src/lib/effects.ts` and left the `Effect.render` interface unchanged.
- Tightened `configuration` typing from `Record<string, any>` to `Record<string, unknown>` and asserted the array with `satisfies Effect[]` to preserve type conformance.
- Added an ESLint rule in `eslint.config.js` to allow underscore-prefixed intentionally unused parameters via `@typescript-eslint/no-unused-vars` configuration.

### Testing
- Ran `npm run lint`, which completed successfully with existing warnings only (no errors).
- Ran `npm run build`, which produced a successful production build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b261b8898832aa847d8e753f5049d)