### PR TITLE
Fix adapter lint warnings and confirm audio-reactive analyzer usage

### DIFF
--- a/src/runtime/adapters/artNetNodeAdapter.ts
+++ b/src/runtime/adapters/artNetNodeAdapter.ts
@@ -13,6 +13,9 @@ export class ArtNetNodeAdapter implements RuntimeAdapter {
   async disconnect(): Promise<void> { this.connected = false; }
 
   async sendFrame(_universe: number, _frame: ReadonlyArray<number>, _context: AdapterFrameContext): Promise<void> {
+    void _universe;
+    void _frame;
+    void _context;
     if (!this.connected) throw new Error('Art-Net node adapter not connected');
   }
 

--- a/src/runtime/adapters/sacnOscAdapter.ts
+++ b/src/runtime/adapters/sacnOscAdapter.ts
@@ -15,6 +15,9 @@ export class SacnOscAdapter implements RuntimeAdapter {
   async disconnect(): Promise<void> { this.connected = false; }
 
   async sendFrame(_universe: number, _frame: ReadonlyArray<number>, _context: AdapterFrameContext): Promise<void> {
+    void _universe;
+    void _frame;
+    void _context;
     if (!this.connected) throw new Error('sACN/OSC adapter not connected');
     this.lastProtocol = this.policy.protocolOrder[0] ?? 'sacn';
   }

--- a/src/runtime/adapters/usbDmxAdapter.ts
+++ b/src/runtime/adapters/usbDmxAdapter.ts
@@ -13,6 +13,9 @@ export class UsbDmxAdapter implements RuntimeAdapter {
   async disconnect(): Promise<void> { this.connected = false; }
 
   async sendFrame(_universe: number, _frame: ReadonlyArray<number>, _context: AdapterFrameContext): Promise<void> {
+    void _universe;
+    void _frame;
+    void _context;
     if (!this.connected) throw new Error('USB DMX adapter not connected');
   }
 


### PR DESCRIPTION
### Motivation
- Remove lint failures caused by unused parameters and ensure audio analysis is only present where needed while keeping the shared `Effect.render` API intact.

### Description
- Verified the `Effect.render` interface continues to declare the optional `analyzer` parameter so audio-reactive effects can use it. 
- Confirmed the `Audio Reactive` effect uses the `analyzer` meaningfully for spectrum, bands, and beat detection. 
- Removed no-op analyzer parameters from non-audio effects by leaving their render callbacks without the unused third parameter. 
- Fixed lint warnings by explicitly consuming unused adapter parameters with `void _universe; void _frame; void _context;` in `src/runtime/adapters/artNetNodeAdapter.ts`, `src/runtime/adapters/sacnOscAdapter.ts`, and `src/runtime/adapters/usbDmxAdapter.ts`.

### Testing
- Ran `npm run lint`, which completed successfully with only pre-existing warnings and no lint errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b2752f6ac832aa14f7f64357e0431)