### PR TITLE
Mark runtime adapter sendFrame parameters as used

### DIFF
--- a/src/runtime/adapters/artNetNodeAdapter.ts
+++ b/src/runtime/adapters/artNetNodeAdapter.ts
@@ -12,10 +12,10 @@ export class ArtNetNodeAdapter implements RuntimeAdapter {
   async connect(): Promise<void> { this.connected = true; }
   async disconnect(): Promise<void> { this.connected = false; }
 
-  async sendFrame(_universe: number, _frame: ReadonlyArray<number>, _context: AdapterFrameContext): Promise<void> {
-    void _universe;
-    void _frame;
-    void _context;
+  async sendFrame(universe: number, frame: ReadonlyArray<number>, context: AdapterFrameContext): Promise<void> {
+    void universe;
+    void frame;
+    void context;
     if (!this.connected) throw new Error('Art-Net node adapter not connected');
   }
 

--- a/src/runtime/adapters/sacnOscAdapter.ts
+++ b/src/runtime/adapters/sacnOscAdapter.ts
@@ -14,10 +14,10 @@ export class SacnOscAdapter implements RuntimeAdapter {
   async connect(): Promise<void> { this.connected = true; }
   async disconnect(): Promise<void> { this.connected = false; }
 
-  async sendFrame(_universe: number, _frame: ReadonlyArray<number>, _context: AdapterFrameContext): Promise<void> {
-    void _universe;
-    void _frame;
-    void _context;
+  async sendFrame(universe: number, frame: ReadonlyArray<number>, context: AdapterFrameContext): Promise<void> {
+    void universe;
+    void frame;
+    void context;
     if (!this.connected) throw new Error('sACN/OSC adapter not connected');
     this.lastProtocol = this.policy.protocolOrder[0] ?? 'sacn';
   }

--- a/src/runtime/adapters/usbDmxAdapter.ts
+++ b/src/runtime/adapters/usbDmxAdapter.ts
@@ -12,10 +12,10 @@ export class UsbDmxAdapter implements RuntimeAdapter {
   async connect(): Promise<void> { this.connected = true; }
   async disconnect(): Promise<void> { this.connected = false; }
 
-  async sendFrame(_universe: number, _frame: ReadonlyArray<number>, _context: AdapterFrameContext): Promise<void> {
-    void _universe;
-    void _frame;
-    void _context;
+  async sendFrame(universe: number, frame: ReadonlyArray<number>, context: AdapterFrameContext): Promise<void> {
+    void universe;
+    void frame;
+    void context;
     if (!this.connected) throw new Error('USB DMX adapter not connected');
   }
 


### PR DESCRIPTION
### Motivation
- Avoid unused-parameter linting/TypeScript warnings in adapter `sendFrame` implementations by using meaningful parameter names and explicitly marking them as used while preserving the runtime interface.

### Description
- Replaced leading-underscore parameter names with `universe`, `frame`, and `context` and added `void universe; void frame; void context;` in `sendFrame` implementations in `src/runtime/adapters/artNetNodeAdapter.ts`, `src/runtime/adapters/sacnOscAdapter.ts`, and `src/runtime/adapters/usbDmxAdapter.ts`.

### Testing
- Ran `npm run lint` which completed successfully with the repository's existing warnings and no new errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b27fba7b8832a8964f19e205e8c2a)