### PR TITLE
Fix AudioVisualizer WaveSurfer effect dependencies

### DIFF
--- a/src/components/AudioVisualizer.tsx
+++ b/src/components/AudioVisualizer.tsx
@@ -33,9 +33,10 @@ export function AudioVisualizer({ audioUrl, isPlaying, onPlay, onPause }: AudioV
 
       return () => {
         wavesurfer.current?.destroy();
+        wavesurfer.current = null;
       };
     }
-  }, [audioUrl]);
+  }, [audioUrl, onPlay, onPause]);
 
   useEffect(() => {
     if (wavesurfer.current) {


### PR DESCRIPTION
### Motivation
- Ensure the WaveSurfer instance is properly torn down and recreated when its event handler callbacks change by tracking `onPlay` and `onPause` in the initialization effect dependencies.
- Reduce unexpected reinitialization when parent components pass stable callbacks by recommending memoization of inline handlers with `useCallback` at the call site.

### Description
- Added `onPlay` and `onPause` to the WaveSurfer initialization `useEffect` dependency array (`[audioUrl, onPlay, onPause]`).
- Ensure the cleanup not only calls `destroy()` on the WaveSurfer instance but also resets `wavesurfer.current = null` so a new instance can be created cleanly.

### Testing
- Ran `npm run lint`, which completed successfully with `0` errors and `3` warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b29fc3ca8832a95335f962d3797ce)