### PR TITLE
Split shared state from React component modules

### DIFF
--- a/src/components/layout/DiagnosticsPanel.tsx
+++ b/src/components/layout/DiagnosticsPanel.tsx
@@ -1,5 +1,5 @@
 import { AlertTriangle, Download, Shield } from 'lucide-react';
-import { useAppState } from '../../context/AppStateContext';
+import { useAppState } from '../../context/appState';
 import { getCurrentEnvironmentDiagnostics } from '../../lib/environmentDiagnostics';
 import { DESKTOP_RUNTIME_UNAVAILABLE_MESSAGE, isWebRuntime } from '../../lib/runtimeEnvironment';
 

--- a/src/components/layout/EffectSidePanel.tsx
+++ b/src/components/layout/EffectSidePanel.tsx
@@ -1,5 +1,5 @@
 import { Settings } from 'lucide-react';
-import { useAppState } from '../../context/AppStateContext';
+import { useAppState } from '../../context/appState';
 import { effects } from '../../lib/effects';
 import { EffectHistoryList } from '../EffectHistoryList';
 import { PresetManager } from '../PresetManager';

--- a/src/components/layout/HeroSection.tsx
+++ b/src/components/layout/HeroSection.tsx
@@ -1,6 +1,6 @@
 import { ChevronRight, Github, Maximize2 } from 'lucide-react';
 import { VirtualStageCanvas } from './VirtualStageCanvas';
-import { useAppState } from '../../context/AppStateContext';
+import { useAppState } from '../../context/appState';
 
 export function HeroSection() {
   const {

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -1,6 +1,6 @@
 import { Activity, Github, Lightbulb } from 'lucide-react';
 import { UserMenu } from '../UserMenu';
-import { useAppState } from '../../context/AppStateContext';
+import { useAppState } from '../../context/appState';
 
 export function Navbar() {
   const { profile, openAuthModal, diagnostics } = useAppState();

--- a/src/components/layout/PlayerBar.tsx
+++ b/src/components/layout/PlayerBar.tsx
@@ -1,5 +1,5 @@
 import { MinusCircle, Pause, Play, PlusCircle, Sliders, Volume2, VolumeX } from 'lucide-react';
-import { useAppState } from '../../context/AppStateContext';
+import { useAppState } from '../../context/appState';
 import { effects } from '../../lib/effects';
 
 export function PlayerBar() {

--- a/src/components/layout/VirtualStageCanvas.tsx
+++ b/src/components/layout/VirtualStageCanvas.tsx
@@ -1,5 +1,5 @@
 import { Command, Eye, Laptop2 } from 'lucide-react';
-import { useAppState } from '../../context/AppStateContext';
+import { useAppState } from '../../context/appState';
 import { useVirtualStageCanvas } from '../../hooks/useVirtualStageCanvas';
 
 export function VirtualStageCanvas() {

--- a/src/context/AppStateContext.tsx
+++ b/src/context/AppStateContext.tsx
@@ -1,7 +1,6 @@
-import { createContext, useContext, type ReactNode } from 'react';
+import type { ReactNode } from 'react';
+import { AppStateContext } from './appState';
 import type { AppStateValue } from './AppStateTypes';
-
-const AppStateContext = createContext<AppStateValue | null>(null);
 
 interface AppStateProviderProps {
   children: ReactNode;
@@ -10,12 +9,4 @@ interface AppStateProviderProps {
 
 export function AppStateProvider({ children, value }: AppStateProviderProps) {
   return <AppStateContext.Provider value={value}>{children}</AppStateContext.Provider>;
-}
-
-export function useAppState() {
-  const context = useContext(AppStateContext);
-  if (!context) {
-    throw new Error('useAppState must be used within AppStateProvider');
-  }
-  return context;
 }

--- a/src/context/appState.ts
+++ b/src/context/appState.ts
@@ -1,0 +1,12 @@
+import { createContext, useContext } from 'react';
+import type { AppStateValue } from './AppStateTypes';
+
+export const AppStateContext = createContext<AppStateValue | null>(null);
+
+export function useAppState() {
+  const context = useContext(AppStateContext);
+  if (!context) {
+    throw new Error('useAppState must be used within AppStateProvider');
+  }
+  return context;
+}

--- a/src/features/copilot/CopilotWorkspace.tsx
+++ b/src/features/copilot/CopilotWorkspace.tsx
@@ -1,74 +1,13 @@
 import { useMemo, useReducer, useState } from 'react';
 
-export type Variant = 'safe' | 'balanced' | 'creative';
+import { copilotReducer, initialCopilotState, type Variant } from './copilotState';
+
 type ShortcutProfile = 'busking' | 'playback' | 'tech';
-
-type CueChange = { attributeBlock: string; before: string; after: string };
-type CueSuggestion = {
-  id: string;
-  label: string;
-  confidence: number;
-  reason: string;
-  impacts: { universes: string[]; fixtures: string[]; scenes: string[] };
-  changes: CueChange[];
-};
-type Decision = { id: string; actor: string; at: string; target: string; action: 'accept' | 'reject' | 'merge'; why: string };
-
-type CopilotState = { brief: string; versions: Record<Variant, CueSuggestion[]>; selectedVariant: Variant; acceptedCueIds: string[]; decisionHistory: Decision[]; requiresValidation: boolean };
-
-type CopilotAction =
-  | { type: 'brief/update'; payload: string }
-  | { type: 'variant/select'; payload: Variant }
-  | { type: 'generation/mock' }
-  | { type: 'cue/accept'; payload: { cueId: string; actor: string; why: string } }
-  | { type: 'cue/reject'; payload: { cueId: string; actor: string; why: string } }
-  | { type: 'batch/merge'; payload: { actor: string; why: string } }
-  | { type: 'show/validate' };
 
 const shortcutPresets: Record<ShortcutProfile, { nextCue: string; blackout: string; safetyAck: string; flash: string }> = {
   busking: { nextCue: 'Space', blackout: 'B', safetyAck: 'Shift+Enter', flash: 'F' },
   playback: { nextCue: 'Enter', blackout: 'Ctrl+B', safetyAck: 'Ctrl+Enter', flash: 'Shift+F' },
   tech: { nextCue: 'N', blackout: 'Q', safetyAck: 'A', flash: 'S' },
-};
-
-const mockCueSuggestions = (variant: Variant): CueSuggestion[] => [
-  {
-    id: `${variant}-cue-1`,
-    label: `${variant.toUpperCase()} Intro wash`,
-    confidence: variant === 'safe' ? 0.91 : variant === 'balanced' ? 0.86 : 0.74,
-    reason: 'Préserve la lisibilité du plateau tout en accompagnant la montée.',
-    impacts: { universes: ['U1'], fixtures: ['Wash-1', 'Wash-2'], scenes: ['Intro'] },
-    changes: [
-      { attributeBlock: 'Intensity', before: '35%', after: variant === 'creative' ? '62%' : '50%' },
-      { attributeBlock: 'Color', before: 'Deep blue', after: variant === 'safe' ? 'Soft cyan' : 'Magenta/Blue' }
-    ]
-  },
-  {
-    id: `${variant}-cue-2`,
-    label: `${variant.toUpperCase()} Drop accent`,
-    confidence: variant === 'creative' ? 0.8 : 0.88,
-    reason: 'Accentuation rythmique sur la rupture sans strobe continu.',
-    impacts: { universes: ['U1', 'U2'], fixtures: ['Beam-1', 'Beam-2', 'Strobe-1'], scenes: ['Drop'] },
-    changes: [
-      { attributeBlock: 'Position', before: 'Center', after: 'Wide fan' },
-      { attributeBlock: 'Beam', before: 'Narrow', after: 'Medium' }
-    ]
-  }
-];
-
-export const initialCopilotState: CopilotState = { brief: '', versions: { safe: [], balanced: [], creative: [] }, selectedVariant: 'balanced', acceptedCueIds: [], decisionHistory: [], requiresValidation: true };
-
-export const copilotReducer = (state: CopilotState, action: CopilotAction): CopilotState => {
-  switch (action.type) {
-    case 'brief/update': return { ...state, brief: action.payload };
-    case 'variant/select': return { ...state, selectedVariant: action.payload };
-    case 'generation/mock': return { ...state, versions: { safe: mockCueSuggestions('safe'), balanced: mockCueSuggestions('balanced'), creative: mockCueSuggestions('creative') }, acceptedCueIds: [], requiresValidation: true };
-    case 'cue/accept': return { ...state, acceptedCueIds: state.acceptedCueIds.includes(action.payload.cueId) ? state.acceptedCueIds : [...state.acceptedCueIds, action.payload.cueId], decisionHistory: [...state.decisionHistory, { id: `decision-${state.decisionHistory.length + 1}`, actor: action.payload.actor, at: new Date().toISOString(), target: action.payload.cueId, action: 'accept', why: action.payload.why }] };
-    case 'cue/reject': return { ...state, acceptedCueIds: state.acceptedCueIds.filter((id) => id !== action.payload.cueId), decisionHistory: [...state.decisionHistory, { id: `decision-${state.decisionHistory.length + 1}`, actor: action.payload.actor, at: new Date().toISOString(), target: action.payload.cueId, action: 'reject', why: action.payload.why }] };
-    case 'batch/merge': return { ...state, decisionHistory: [...state.decisionHistory, { id: `decision-${state.decisionHistory.length + 1}`, actor: action.payload.actor, at: new Date().toISOString(), target: `batch:${state.selectedVariant}`, action: 'merge', why: action.payload.why }], requiresValidation: true };
-    case 'show/validate': return { ...state, requiresValidation: false };
-    default: return state;
-  }
 };
 
 export function CopilotWorkspace() {

--- a/src/features/copilot/copilotState.ts
+++ b/src/features/copilot/copilotState.ts
@@ -1,0 +1,63 @@
+export type Variant = 'safe' | 'balanced' | 'creative';
+
+type CueChange = { attributeBlock: string; before: string; after: string };
+type CueSuggestion = {
+  id: string;
+  label: string;
+  confidence: number;
+  reason: string;
+  impacts: { universes: string[]; fixtures: string[]; scenes: string[] };
+  changes: CueChange[];
+};
+type Decision = { id: string; actor: string; at: string; target: string; action: 'accept' | 'reject' | 'merge'; why: string };
+
+export type CopilotState = { brief: string; versions: Record<Variant, CueSuggestion[]>; selectedVariant: Variant; acceptedCueIds: string[]; decisionHistory: Decision[]; requiresValidation: boolean };
+
+export type CopilotAction =
+  | { type: 'brief/update'; payload: string }
+  | { type: 'variant/select'; payload: Variant }
+  | { type: 'generation/mock' }
+  | { type: 'cue/accept'; payload: { cueId: string; actor: string; why: string } }
+  | { type: 'cue/reject'; payload: { cueId: string; actor: string; why: string } }
+  | { type: 'batch/merge'; payload: { actor: string; why: string } }
+  | { type: 'show/validate' };
+
+const mockCueSuggestions = (variant: Variant): CueSuggestion[] => [
+  {
+    id: `${variant}-cue-1`,
+    label: `${variant.toUpperCase()} Intro wash`,
+    confidence: variant === 'safe' ? 0.91 : variant === 'balanced' ? 0.86 : 0.74,
+    reason: 'Préserve la lisibilité du plateau tout en accompagnant la montée.',
+    impacts: { universes: ['U1'], fixtures: ['Wash-1', 'Wash-2'], scenes: ['Intro'] },
+    changes: [
+      { attributeBlock: 'Intensity', before: '35%', after: variant === 'creative' ? '62%' : '50%' },
+      { attributeBlock: 'Color', before: 'Deep blue', after: variant === 'safe' ? 'Soft cyan' : 'Magenta/Blue' }
+    ]
+  },
+  {
+    id: `${variant}-cue-2`,
+    label: `${variant.toUpperCase()} Drop accent`,
+    confidence: variant === 'creative' ? 0.8 : 0.88,
+    reason: 'Accentuation rythmique sur la rupture sans strobe continu.',
+    impacts: { universes: ['U1', 'U2'], fixtures: ['Beam-1', 'Beam-2', 'Strobe-1'], scenes: ['Drop'] },
+    changes: [
+      { attributeBlock: 'Position', before: 'Center', after: 'Wide fan' },
+      { attributeBlock: 'Beam', before: 'Narrow', after: 'Medium' }
+    ]
+  }
+];
+
+export const initialCopilotState: CopilotState = { brief: '', versions: { safe: [], balanced: [], creative: [] }, selectedVariant: 'balanced', acceptedCueIds: [], decisionHistory: [], requiresValidation: true };
+
+export const copilotReducer = (state: CopilotState, action: CopilotAction): CopilotState => {
+  switch (action.type) {
+    case 'brief/update': return { ...state, brief: action.payload };
+    case 'variant/select': return { ...state, selectedVariant: action.payload };
+    case 'generation/mock': return { ...state, versions: { safe: mockCueSuggestions('safe'), balanced: mockCueSuggestions('balanced'), creative: mockCueSuggestions('creative') }, acceptedCueIds: [], requiresValidation: true };
+    case 'cue/accept': return { ...state, acceptedCueIds: state.acceptedCueIds.includes(action.payload.cueId) ? state.acceptedCueIds : [...state.acceptedCueIds, action.payload.cueId], decisionHistory: [...state.decisionHistory, { id: `decision-${state.decisionHistory.length + 1}`, actor: action.payload.actor, at: new Date().toISOString(), target: action.payload.cueId, action: 'accept', why: action.payload.why }] };
+    case 'cue/reject': return { ...state, acceptedCueIds: state.acceptedCueIds.filter((id) => id !== action.payload.cueId), decisionHistory: [...state.decisionHistory, { id: `decision-${state.decisionHistory.length + 1}`, actor: action.payload.actor, at: new Date().toISOString(), target: action.payload.cueId, action: 'reject', why: action.payload.why }] };
+    case 'batch/merge': return { ...state, decisionHistory: [...state.decisionHistory, { id: `decision-${state.decisionHistory.length + 1}`, actor: action.payload.actor, at: new Date().toISOString(), target: `batch:${state.selectedVariant}`, action: 'merge', why: action.payload.why }], requiresValidation: true };
+    case 'show/validate': return { ...state, requiresValidation: false };
+    default: return state;
+  }
+};


### PR DESCRIPTION
### Motivation
- Reduce Fast Refresh / `react-refresh/only-export-components` warnings by moving non-component hooks, types, and constants out of `.tsx` component modules.
- Keep `.tsx` files focused on React components and place shared values in plain `.ts` modules to make imports stable across HMR.

### Description
- Moved the AppState context object and `useAppState` hook into `src/context/appState.ts` and kept the `AppStateProvider` component in `src/context/AppStateContext.tsx`.
- Created `src/features/copilot/copilotState.ts` that exports `Variant`, `CopilotState`, `CopilotAction`, `initialCopilotState`, `copilotReducer`, and the `mockCueSuggestions` helper.
- Updated `src/features/copilot/CopilotWorkspace.tsx` to import `copilotReducer`, `initialCopilotState`, and `Variant` from the new `copilotState` module and removed shared state/type code from the TSX file.
- Updated multiple layout components to import `useAppState` from `src/context/appState` instead of `src/context/AppStateContext` and added the two new files to the repo.

### Testing
- Ran `npm run lint` which completed successfully with no lint errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b2aa6b4e0832ab6b2ca607063e7bb)