### PR TITLE
Set GH_RELEASE_OWNER and GH_RELEASE_REPO in CI desktop build step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
         run: npm run lint
 
       - name: Validate frontend and desktop package
+        env:
+          GH_RELEASE_OWNER: ${{ github.repository_owner }}
+          GH_RELEASE_REPO: ${{ github.event.repository.name }}
         run: |
           npm run build
           npm run compile --prefix desktop


### PR DESCRIPTION
### Motivation
- Provide the environment variables required by `desktop/electron-builder.yml` so `electron-builder` can expand `${env.GH_RELEASE_OWNER}` and `${env.GH_RELEASE_REPO}` during the CI `Validate frontend and desktop package` step.

### Description
- Add `GH_RELEASE_OWNER: ${{ github.repository_owner }}` and `GH_RELEASE_REPO: ${{ github.event.repository.name }}` to the `Validate frontend and desktop package` step in `.github/workflows/ci.yml` while keeping the existing `npm run build`, `npm run compile --prefix desktop`, and `npm run build:dir --prefix desktop` commands unchanged.

### Testing
- Ran `git diff --check` which passed, and executed `GH_RELEASE_OWNER=test-owner GH_RELEASE_REPO=test-repo npm run build && GH_RELEASE_OWNER=test-owner GH_RELEASE_REPO=test-repo npm run compile --prefix desktop && GH_RELEASE_OWNER=test-owner GH_RELEASE_REPO=test-repo npm run build:dir --prefix desktop`, where frontend build and desktop compile succeeded and `electron-builder` progressed past env expansion but then failed downloading Electron with a `403 Forbidden` (failure unrelated to env expansion).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b2cd4baa8832aa2ebb51e8ee6aa5f)